### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ export class Company {
     -   generates swggger decorator. default value is **true**
 -   _makeIndexFile_
     -   makes index file, default value is **true**
+-   _seperateRelationFields_
+    -   Puts relational fields into different file for each model. This way the class will match the object returned by a Prisma query, default value is **false**
 
 ### **How it works?**
 

--- a/src/components/field.ts
+++ b/src/components/field.ts
@@ -1,4 +1,4 @@
-import { FIELD_TEMPLATE } from '../templates/field'
+import { FIELD_TEMPLATE, FIELD_TEMPLATE_DEFAULT } from '../templates/field'
 import { Echoable } from '../interfaces/echoable'
 import { Decoratable } from '../components/decorator'
 
@@ -13,7 +13,8 @@ export class PrismaField extends Decoratable implements Echoable {
 		if (this.nullable === true) {
 			name += '?'
 		}
-		return FIELD_TEMPLATE.replace('#!{NAME}', name)
+		const template = this.default ? FIELD_TEMPLATE_DEFAULT : FIELD_TEMPLATE
+		return template.replace('#!{NAME}', name)
 			.replace('#!{TYPE}', this.type)
 			.replace('#!{DECORATORS}', this.echoDecorators())
 			.replace('#!{DEFAULT}', this.default ?? 'undefined')

--- a/src/convertor.ts
+++ b/src/convertor.ts
@@ -63,8 +63,9 @@ export class PrismaConvertor {
 		dmmfField: DMMF.Field,
 	): PrismaDecorator => {
 		const options: Record<string, any> = {}
+		const name = dmmfField.isRequired === true ? 'ApiProperty' : 'ApiPropertyOptional'
 		const decorator = new PrismaDecorator({
-			name: 'ApiProperty',
+			name,
 			importFrom: '@nestjs/swagger',
 		})
 

--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -20,6 +20,7 @@ generator prismaClassGenerator {
 	output		= (string)
 	dryRun   	= (boolean)
 	useSwagger	= (boolean)
+	seperateRelationFields = (boolean),
 }`)
 		log(`Your Input : ${JSON.stringify(e.config)}`)
 		return

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -12,6 +12,7 @@ export interface PrismaClassGeneratorConfig {
 	useSwagger: boolean
 	dryRun: boolean
 	makeIndexFile: boolean
+	seperateRelationFields: boolean
 	use: boolean
 }
 
@@ -77,7 +78,11 @@ export class PrismaClassGenerator {
 		convertor.dmmf = dmmf
 		convertor.config = config
 
-		const prismaClasses = convertor.convertModels()
+		const prismaClassesPairs = convertor.convertModels()
+		let prismaClasses = prismaClassesPairs.map((pair) => pair[0])
+		
+		if (config.seperateRelationFields) prismaClasses = prismaClassesPairs.flat()
+
 		const files = prismaClasses.map((c) => c.toFileClass(output))
 
 		const classToPath = files.reduce((result, fileRow) => {
@@ -136,6 +141,7 @@ export class PrismaClassGenerator {
 				useSwagger: true,
 				dryRun: true,
 				makeIndexFile: true,
+				seperateRelationFields: false,
 			},
 			config,
 		)

--- a/src/templates/field.ts
+++ b/src/templates/field.ts
@@ -1,3 +1,7 @@
-export const FIELD_TEMPLATE = `	#!{DECORATORS}
+export const FIELD_TEMPLATE_DEFAULT = `	#!{DECORATORS}
 	#!{NAME}: #!{TYPE} = #!{DEFAULT}
+	`
+
+export const FIELD_TEMPLATE = `	#!{DECORATORS}
+	#!{NAME}: #!{TYPE}
 	`


### PR DESCRIPTION
## Fixes
### commit 48da8556ddc12d92607918c4f8325b2d02ded9c0
In the generated files it assigned undefined to non optional fields, which is not intuitive in the context of typescript. A property not marked optional with "?" should not have the value of undefined.
### commit 6becf7780a22c60b3d6acf4e75047b4e6ba59c58
Change non required fields swagger decorator to optional. The NestJs swagger decorator has an ApiPropertyOptional alternative which marks the property optional in the OpenAPI specification. This fix marks all non required fields as optional.

## Proposed Changes
### commit ed40d8a2c58cf4354a0b1283f24368a302a31a17
- add option to generate seperate classes for relation fields

Prisma's standard query result is an object without relations. When using the generated classes for response types in Nestjs it is very unpractical to omit all relations in a dto manually or to have to pick non relational fields. I created the option this way so it won't break the generator's api. If you leave out the option the generator works just like it used to. If you set the seperateRelationFields option to true, it generates two classes for each model, one without relations, and one
only containing them. This way it is easier to use mixins.
#### example:

```ts
import { IntersectionType, PickType } from '@nestjs/swagger';

class UserDto extends IntersectionType(User, PickType(UserRelations, ['Projects'])) {}
```