### PR TITLE
Feature/prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is Prisma's basic way of doing things, and I love this approach.
 However, there are limitations because of these characteristics.
 A typical example is NestJS. In order to use `@nestjs/swagger`, the entity must be defined as class.
 
-So I created a simple tool that generates a typescript file based on `schema.prisma`.
+So I created a simple tool that generates a typescript file based on `schema.prisma`. The generated Classes are formatted with prettier, using the user's prettier config file if present.
 This will reduce the effort to define classes directly while using the same single source of truth (`schema.prisma`)
 
 ## **NestJS**
@@ -256,6 +256,7 @@ It is defined as an additional generator in the `schema.prisma` file and will op
 -   generate Classes from prisma model definition
 -   Support Basic Type and Relation
 -   Support option to generate Swagger Decorator
+-   Format generated Classes with prettier, using the user's prettier config file if present
 
 ### **Future Plan**
 
@@ -263,7 +264,6 @@ It is defined as an additional generator in the `schema.prisma` file and will op
 -   Support all types in prisma.schema
 -   Support TypeGraphQL
 -   Support DTO
--   Support using user's own format like .prettierrc.json
 -   Support custom path, case or name per each model
 
 ---

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A typical example is NestJS. In order to use `@nestjs/swagger`, the entity must 
 So I created a simple tool that generates a typescript file based on `schema.prisma`. The generated Classes are formatted with prettier, using the user's prettier config file if present.
 This will reduce the effort to define classes directly while using the same single source of truth (`schema.prisma`)
 
+The Prisma JS Client returns objects that does not contain the model's relational fields. The Generator can create two seperate files per model, one that matches the Prisma Js Client's interfaces, and one that contains only the relational fields. You can set the _seperateRelationFields_ option to **true** if you want to generate two seperate classes for each model. The default value is **false**.
+
 ## **NestJS**
 
 > [NestJS](https://nestjs.com/) is a framework for building efficient, scalable Node.js server-side applications.
@@ -39,6 +41,18 @@ export class Company {
 	@ApiProperty({ type: Boolean }) // swagger
 	isUse: boolean
 }
+```
+
+If you set the _seperateRelationFields_ option to **true** and generate seperate relational classes, you can compose a class from the two, only contanining the included relations.
+This example below is using methods from the `@nestjs/swagger` package. This example creates a class with all of the properties of the Product class and the category relational property from the generated relational class.
+
+```typescript
+import { IntersectionType, PickType } from '@nestjs/swagger';
+import { Product } from './product'
+import { ProductRelations } from './product_relations'
+
+export class ProductDto extends IntersectionType(Product, PickType(ProductRelations, ['category'] as const)) {}
+
 ```
 
 ### **Usage**

--- a/package.json
+++ b/package.json
@@ -33,11 +33,12 @@
 		"@prisma/client": "^3.7.0",
 		"@prisma/generator-helper": "^3.7.0",
 		"@prisma/sdk": "^3.7.0",
-		"change-case": "^4.1.2"
+		"change-case": "^4.1.2",
+		"prettier": "2.5.1"
 	},
 	"devDependencies": {
 		"@types/node": "^16.6.2",
-		"prettier": "^2.4.1",
+		"@types/prettier": "2.4.3",
 		"prisma": "^3.7.0",
 		"swagger-ui-express": "^4.1.6",
 		"ts-node": "^10.2.1",

--- a/src/components/file.ts
+++ b/src/components/file.ts
@@ -3,7 +3,7 @@ import { PrismaClass } from './class'
 import { PrismaImport } from './import'
 import * as fs from 'fs'
 import * as path from 'path'
-import { getRelativeTSPath, log, writeTSFile } from '../util'
+import { getRelativeTSPath, log, prettierFormat, writeTSFile } from '../util'
 import { PrismaClassGenerator } from '../generator'
 import { Echoable } from '../interfaces/echoable'
 
@@ -101,8 +101,10 @@ export class PrismaClassFile implements Echoable {
 	}
 
 	write(dryRun: boolean) {
+		const generator = PrismaClassGenerator.getInstance()
 		const filePath = path.resolve(this.dir, this.filename)
-		writeTSFile(filePath, this.echo(), dryRun)
+		const content = prettierFormat(this.echo(), generator.prettierOptions)
+		writeTSFile(filePath, content, dryRun)
 	}
 
 	getRelativePath(to: string): string {

--- a/src/convertor.ts
+++ b/src/convertor.ts
@@ -129,12 +129,12 @@ export class PrismaConvertor {
 			})
 		
 		const relationTypes = model.fields
-			.filter((field) => field.relationName && model.name !== field.type)
+			.filter((field) => field.relationName && (seperateRelationFields || model.name !== field.type))
 			.map((v) => v.type)
 		const enums = model.fields.filter((field) => field.kind === 'enum')
 
 		pClass.fields = fields
-		pClass.relationTypes = uniquify(relationTypes)
+		pClass.relationTypes = seperateRelationFields ? [] : uniquify(relationTypes)
 		pClass.enumTypes = enums.map((field) => field.type.toString())
 
 		rClass.fields = rFields

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs'
 import { GENERATOR_NAME } from './generator'
 import { GeneratorFormatNotValidError } from './error-handler'
 import { DMMF } from '@prisma/generator-helper'
+import { Options, format } from 'prettier'
 
 export const capitalizeFirst = (src: string) => {
 	return src.charAt(0).toUpperCase() + src.slice(1)
@@ -71,4 +72,8 @@ export const writeTSFile = (
 		fs.mkdirSync(dirname, { recursive: true })
 	}
 	fs.writeFileSync(fullPath, content)
+}
+
+export const prettierFormat = (content: string, options: Options = {}) => {
+	return format(content, {...options, parser: 'typescript'})
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,6 +258,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
+"@types/prettier@2.4.3":
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.3.tgz#a3c65525b91fca7da00ab1a3ac2b5a2a4afbffbf"
+  integrity sha512-QzSuZMBuG5u8HqYz01qtMdg/Jfctlnvj1z/lYnIDXs/golxw0fxtRAHd9KrzjR7Yxz1qVeI00o0kiO3PmVdJ9w==
+
 "@types/retry@^0.12.0":
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.1.tgz#d8f1c0d0dc23afad6dc16a9e993a0865774b4065"
@@ -1333,10 +1338,10 @@ pkg-dir@^4.1.0:
   dependencies:
     find-up "^4.0.0"
 
-prettier@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
-  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+prettier@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
 prettysize@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Fixes

### commit d517b17d405adbd53eacc88ec4d8e1e077f905b8
Fixes a small bug in the seperate relational fields option. If there was a self relation the generated relational file did not contained an import for the non relational class. Also removes unused imports from the non relational classes.

### commit f436dfd9fb88908932aa3c57ba39024e1a52c724
Adds some examples and better description on the behaviour of the seperateRelationFields option.

## Proposed Changes

### Prettier formatting - commit af81d643a54e930ec756933d32e6ac9194379d27

There was an item in the possible feature for the future stating you would like to add prettier formatting. I went ahead and implemented this feature. At first it looks for the config file in the generators output directory and upwards from there. If it doesn't find a user defined config file, it starts looking from the main modules directory and upwards. In reality this results in the user's prettier config from their projects root directory if present, if not it will use the config which is used for this project.

All output classes are formatted, with the selected config file.