### PR TITLE
fix: parse options makeIndexFile and seperateRelationFields

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -161,6 +161,8 @@ export class PrismaClassGenerator {
 		)
 		result.useSwagger = parseBoolean(result.useSwagger)
 		result.dryRun = parseBoolean(result.dryRun)
+		result.makeIndexFile = parseBoolean(result.makeIndexFile)
+		result.seperateRelationFields = parseBoolean(result.seperateRelationFields)
 
 		return result
 	}


### PR DESCRIPTION
Fixes #8

## Proposed Changes

Maybe I'm missing something
I'm not experienced with Prisma ORM yet

Have added the fix for `seperateRelationFields` too despite the default being `false` there.
Falsy default means the option works now when overriding `false` with `"true"`, but explicit default would break.

if you think it's important maybe you could change spelling: seperate => separate 
(but that could be problematic given it's a public option)
