### PR TITLE
Fix inconsistency between `export` and `import`

### DIFF
--- a/src/components/file.component.ts
+++ b/src/components/file.component.ts
@@ -83,7 +83,7 @@ export class FileComponent implements Echoable {
 		const generator = PrismaClassGenerator.getInstance()
 		this.prismaClass.relationTypes.forEach((relationClassName) => {
 			this.registerImport(
-				`${pascalCase(relationClassName)}`,
+				`${relationClassName}`,
 				FileComponent.TEMP_PREFIX + relationClassName,
 			)
 		})


### PR DESCRIPTION
The class template and related code export the class as simply `x.name`. However, related entities are forced to `pascalCase` in import, which breaks the import.

This probably works fine if you're doing the Right Thing™ by prisma and naming your models in pascalCase, but it should break in all other cases.


There are more reliable and holistic ways to ensure these names are consistent instead of just fixing the inconsistency as this PR does, but I opted for the most minimal approach here.
