### PR TITLE
feat: add mongodb type support

### DIFF
--- a/src/components/class.component.ts
+++ b/src/components/class.component.ts
@@ -9,6 +9,7 @@ export class ClassComponent extends BaseComponent implements Echoable {
 	relationTypes?: string[]
 	enumTypes?: string[] = []
 	extra?: string = ''
+	types?: string[]
 
 	echo = () => {
 		const fieldContent = this.fields.map((_field) => _field.echo())

--- a/src/components/file.component.ts
+++ b/src/components/file.component.ts
@@ -101,6 +101,12 @@ export class FileComponent implements Echoable {
 			})
 		})
 
+		if (this.prismaClass.types) {
+			this.prismaClass.types.forEach(type => {
+				this.registerImport(type + "Type", "./" + type.toLowerCase() + "_type")
+			})
+		}
+
 		if (generator.getConfig().useGraphQL) {
 			this.registerImport('ID', '@nestjs/graphql')
 			this.registerImport('Int', '@nestjs/graphql')

--- a/src/convertor.ts
+++ b/src/convertor.ts
@@ -216,6 +216,13 @@ export class PrismaConvertor {
 				)
 				.map((v) => v.type),
 		)
+
+		const typesTypes = uniquify(
+			model.fields
+				.filter(field => field.kind == "object" && model.name !== field.type)
+				.map(v => v.type)
+		)
+
 		const enums = model.fields.filter((field) => field.kind === 'enum')
 
 		classComponent.fields = model.fields
@@ -236,6 +243,8 @@ export class PrismaConvertor {
 			extractRelationFields === true
 				? []
 				: enums.map((field) => field.type.toString())
+
+		classComponent.types = typesTypes;
 
 		if (useGraphQL) {
 			const deco = new DecoratorComponent({
@@ -292,12 +301,29 @@ export class PrismaConvertor {
 						useGraphQL: this.config.useGraphQL,
 					}),
 				),
+				...this.dmmf.datamodel.types.map((model) =>
+					this.getClass({
+						model,
+						extractRelationFields: true,
+						postfix: 'Type',
+						useGraphQL: this.config.useGraphQL,
+					}),
+				),
 			]
 		}
 
-		return models.map((model) =>
-			this.getClass({ model, useGraphQL: this.config.useGraphQL }),
-		)
+		return [
+			...models.map((model) =>
+				this.getClass({ model, useGraphQL: this.config.useGraphQL }),
+			),
+			...this.dmmf.datamodel.types.map((model) =>
+				this.getClass({
+					model,
+					postfix: 'Type',
+					useGraphQL: this.config.useGraphQL,
+				}),
+			),
+		]
 	}
 
 	convertField = (dmmfField: DMMF.Field): FieldComponent => {
@@ -352,7 +378,7 @@ export class PrismaConvertor {
 		if (type) {
 			field.type = type
 		} else {
-			field.type = dmmfField.type
+			field.type = dmmfField.type + "Type"
 		}
 
 		if (dmmfField.isList) {


### PR DESCRIPTION
Fixes #48 & #21

## Proposed Changes

- added a basic working version for the mongodb type expression..

I know, this is probably very wrong, but with my limited time I was not able to dive much deeper into the code. 
This probably also breaks some other stuff, I've only tried with `npm run generate:mongodb`

please, since there are some requests to support this, guide me in the correct direction to get this implemented (in a nicer way)
