### PR TITLE
Fix typo : 오타 수정 : prisma/*.prisam

### DIFF
--- a/prisma/mongodb.prisma
+++ b/prisma/mongodb.prisma
@@ -3,7 +3,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-generator clent {
+generator client {
   provider      = "prisma-client-js"
   binaryTargets = ["native", "rhel-openssl-1.0.x", "darwin"]
 }

--- a/prisma/postgresql.prisma
+++ b/prisma/postgresql.prisma
@@ -3,7 +3,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-generator clent {
+generator client {
   provider      = "prisma-client-js"
   binaryTargets = ["native", "rhel-openssl-1.0.x", "darwin"]
 }


### PR DESCRIPTION
# Fix Typo in *.prisma

## 변경 사항
- *.prisma  파일에 오타가 있어 수정을 진행하였습니다.

## 상세 내용
- `generator clent` 라고 표기되어 있던 부분을 올바른 표현인 `generator client`로 수정하였습니다. 

감사합니다.
