### PR TITLE
import relations as ts types to fix circular imports

### DIFF
--- a/src/components/file.component.ts
+++ b/src/components/file.component.ts
@@ -86,6 +86,10 @@ export class FileComponent implements Echoable {
 				`${relationClassName}`,
 				FileComponent.TEMP_PREFIX + relationClassName,
 			)
+			this.registerImport(
+				`type ${relationClassName} as ${relationClassName}AsType`,
+				FileComponent.TEMP_PREFIX + relationClassName
+			)
 		})
 		this.prismaClass.enumTypes.forEach((enumName) => {
 			this.registerImport(enumName, generator.getClientImportPath())

--- a/src/convertor.ts
+++ b/src/convertor.ts
@@ -387,7 +387,11 @@ export class PrismaConvertor {
 		if (type) {
 			field.type = type
 		} else {
-			field.type = dmmfField.type
+			if (dmmfField.relationName) {
+				field.type = `${dmmfField.type}AsType`
+			} else {
+				field.type = dmmfField.type
+			}
 		}
 
 		if (dmmfField.isList) {


### PR DESCRIPTION
Fixes #60 

## Proposed Changes

- Import generated relation types both as classes for use in `ApiProperty` decorators, but also as TypeScript types for use as the field type definition to avoid circular import errors when building the project.

# Example of the result:
```ts
import { users, type users as usersAsType } from './users';
import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';

export class identities {
  @ApiProperty({ type: () => users })
  users: usersAsType;
}

```