### PR TITLE
Update swagger decorator Json type mapping

### DIFF
--- a/src/convertor.ts
+++ b/src/convertor.ts
@@ -162,6 +162,12 @@ export class PrismaConvertor {
 			options.isArray = true
 		}
 
+		if (dmmfField.type === 'Json') {
+			options.type = 'Object'
+			decorator.params.push(options);
+			return decorator
+		}
+
 		let type = this.getPrimitiveMapTypeFromDMMF(dmmfField)
 		if (type && type !== 'any') {
 			options.type = capitalizeFirst(type)


### PR DESCRIPTION
Fixes

```javascript
unexpected error occured
SyntaxError: '(' expected. (27:46)
  25 |  external_id: string 
  26 | 
> 27 |  @ApiProperty({type: Record<string, unknown> | unknown[] | boolean | string | number | null})
     |                                              ^
  28 |  metadata: Record<string, unknown> | unknown[] | boolean | string | number | null 
  29 | 
  30 | }
```

## Proposed Changes

- For swagger decorator, use `Object` for type `Json` instead of typescript types
