### PR TITLE
refactor: adopt TypeScript strict mode (+ verify change-case 5.x ESM compatibility)

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,12 @@
+---
+'prisma-class-generator': patch
+---
+
+Adopt TypeScript `strict` mode across the generator's own source and specs. This is an internal
+type-safety change with no difference in generated output (the golden fixture snapshots are
+byte-identical), but it did tighten a few types that were previously lying about what they can
+hold at runtime: `getPrimitiveMapTypeFromDMMF()` now declares the `undefined` it already returned
+for non-scalar fields, `ImportComponent#getReplacePath()` declares its `null`, `prettierOptions`
+declares the `null` prettier itself returns when a project has no config file, and
+`handleGenerateError()` accepts `unknown` instead of assuming a `catch` block always yields an
+`Error`.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,9 +48,15 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@changesets/changelog-github'
         update-types: ['version-update:semver-major']
-      # change-case 5.x is ESM-only -- untested against this repo's CommonJS-ish build
-      # (tsconfig `module: node16`). Not a hard blocker like the others above, just unverified;
-      # revisit with an actual compatibility check before accepting.
+      # change-case 5.x is ESM-only ("type": "module", exports expose only an `import`
+      # condition) and this package is published as CommonJS, so `require('change-case')`
+      # throws ERR_REQUIRE_ESM -- verified by actually installing 5.4.4 and requiring it under
+      # node 18.20.8 (fails), 20.19.4 (works) and 22.23.1 (works); require(ESM) landed in
+      # 22.12 and was backported to 20.19. So the only thing blocking this bump is the
+      # `engines.node: >=18` floor, not behavior: v4 and v5 `snakeCase` were also diffed over
+      # 20 Prisma-style identifiers (ABCModel, HTTPRequest, User2Post, Model_V2, ...) with
+      # zero differences, so generated filenames would not change. Drop this ignore rule as
+      # soon as this repo's Node floor moves to >=20.19.
       - dependency-name: 'change-case'
         update-types: ['version-update:semver-major']
       # eslint 10.x and @eslint/js 10.x both require Node >=20.19 (9.x supports 18) -- a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,24 @@ npm run generate:*      # regenerate a fixture under prisma/*.prisma (postgresql
   `type`-only import has no runtime value, so TS can't emit a reference to it. Keep both the value
   import (the decorator, e.g. `type: () => Book`, still needs it) and the type-only alias.
 
+## Type safety
+
+`tsconfig.json` has `strict: true` and `src/` is clean under it (specs included — ts-jest
+type-checks them with the same tsconfig, so a spec that ignores a possibly-`undefined` lookup
+fails the test run, not just `npm run typecheck`). Two conventions came out of adopting it, both
+deliberate:
+
+- **Definite-assignment (`!`) is reserved for late-injected singleton state** — `PrismaConvertor`'s
+  `_dmmf`/`_config` and `PrismaClassGenerator`'s `_options`/`rootPath`/`clientPath`, all of which
+  are set through setters right after construction rather than passed in. Don't paper over an
+  ordinary "might be undefined" with `!`; either give the field a real default or make the type
+  admit `undefined` and handle it.
+- **`PrismaClassGeneratorConfig` stays all-optional** so specs can build partial configs, which
+  means call sites that need a concrete value supply the same default `PrismaClassGeneratorOptions`
+  declares (see `run()`'s `config.dryRun ?? true`). `getConfig()` builds its result through a
+  string-keyed record and casts once at the end — indexing the interface with a *union* of keys
+  narrows the assignable type to nothing, so a per-key loop can't be written against it directly.
+
 ## Style
 
 - Tabs, no semicolons, single quotes — see `.prettierrc.json`, run `npm run format`.

--- a/src/components/class.component.ts
+++ b/src/components/class.component.ts
@@ -5,11 +5,19 @@ import { BaseComponent } from './base.component'
 
 export class ClassComponent extends BaseComponent implements Echoable {
 	name: string
-	fields?: FieldComponent[]
-	relationTypes?: string[]
-	enumTypes?: string[] = []
-	extra?: string = ''
+	// filled in by PrismaConvertor#getClass right after construction, which is also why these
+	// start empty rather than being constructor params -- the convertor needs the instance
+	// before it can work out its fields and related type names.
+	fields: FieldComponent[] = []
+	relationTypes: string[] = []
+	enumTypes: string[] = []
+	extra = ''
 	types?: string[]
+
+	constructor(obj: { name: string }) {
+		super(obj)
+		this.name = obj.name
+	}
 
 	echo = () => {
 		const fieldContent = this.fields.map((_field) => _field.echo())

--- a/src/components/field.component.ts
+++ b/src/components/field.component.ts
@@ -4,10 +4,12 @@ import { BaseComponent } from './base.component'
 
 export class FieldComponent extends BaseComponent implements Echoable {
 	name: string
-	nonNullableAssertion: boolean
-	preserveDefaultNullable: boolean
-	nullable: boolean
 	useUndefinedDefault: boolean
+	// only ever switched on by PrismaConvertor#convertField, so "off" is the real default --
+	// echo() below already treats an unset flag exactly like `false`.
+	nonNullableAssertion = false
+	preserveDefaultNullable = false
+	nullable = false
 	default?: string
 	type?: string
 
@@ -35,12 +37,14 @@ export class FieldComponent extends BaseComponent implements Echoable {
 
 		return FIELD_TEMPLATE.replace('#!{NAME}', name)
 			.replace('#!{NAME}', name)
-			.replace('#!{TYPE}', type)
+			.replace('#!{TYPE}', type ?? '')
 			.replace('#!{DECORATORS}', this.echoDecorators())
 			.replace('#!{DEFAULT}', defaultValue)
 	}
 
 	constructor(obj: { name: string; useUndefinedDefault: boolean }) {
 		super(obj)
+		this.name = obj.name
+		this.useUndefinedDefault = obj.useUndefinedDefault
 	}
 }

--- a/src/components/file.component.spec.ts
+++ b/src/components/file.component.spec.ts
@@ -5,6 +5,7 @@ import {
 	resolveRelationImports,
 } from '../generator'
 import { FileComponent } from './file.component'
+import { ImportComponent } from './import.component'
 
 const baseSchema = (
 	modelBlock: string,
@@ -49,6 +50,25 @@ const buildFiles = async (
 	return files
 }
 
+// throwing (rather than returning undefined and letting the assertion below blow up on a
+// property access) keeps a broken lookup reported as "no generated file for class X" instead
+// of "cannot read properties of undefined".
+const findFile = (files: FileComponent[], className: string): FileComponent => {
+	const file = files.find((f) => f.prismaClass.name === className)
+	if (!file) {
+		throw new Error(`no generated file for class "${className}"`)
+	}
+	return file
+}
+
+const findImport = (file: FileComponent, from: string): ImportComponent => {
+	const importRow = file.imports.find((i) => i.from === from)
+	if (!importRow) {
+		throw new Error(`${file.filename} has no import from "${from}"`)
+	}
+	return importRow
+}
+
 const findImportFrom = (
 	file: FileComponent,
 	item: string,
@@ -71,10 +91,8 @@ describe('relation import 경로 해석 (FileComponent + resolveRelationImports)
       }
     `)
 
-		const userFriendFile = files.find(
-			(f) => f.prismaClass.name === 'UserFriend',
-		)
-		const userFile = files.find((f) => f.prismaClass.name === 'User')
+		const userFriendFile = findFile(files, 'UserFriend')
+		const userFile = findFile(files, 'User')
 
 		expect(userFriendFile.filename).toBe('user_friend.ts')
 		expect(userFile.filename).toBe('user.ts')
@@ -99,8 +117,8 @@ describe('relation import 경로 해석 (FileComponent + resolveRelationImports)
       }
     `)
 
-		const authorFile = files.find((f) => f.prismaClass.name === 'Author')
-		const bookFile = files.find((f) => f.prismaClass.name === 'Book')
+		const authorFile = findFile(files, 'Author')
+		const bookFile = findFile(files, 'Book')
 
 		expect(findImportFrom(authorFile, 'Book')).toBe('./book')
 		expect(findImportFrom(bookFile, 'Author')).toBe('./author')
@@ -127,14 +145,14 @@ describe('relation import 경로 해석 (FileComponent + resolveRelationImports)
       }
     `)
 
-		const authorFile = files.find((f) => f.prismaClass.name === 'Author')
-		const bookFile = files.find((f) => f.prismaClass.name === 'Book')
+		const authorFile = findFile(files, 'Author')
+		const bookFile = findFile(files, 'Book')
 
-		const bookImport = authorFile.imports.find((i) => i.from === './book')
+		const bookImport = findImport(authorFile, './book')
 		expect(bookImport.items).toContain('Book')
 		expect(bookImport.items).toContain('type Book as BookAsType')
 
-		const authorImport = bookFile.imports.find((i) => i.from === './author')
+		const authorImport = findImport(bookFile, './author')
 		expect(authorImport.items).toContain('Author')
 		expect(authorImport.items).toContain('type Author as AuthorAsType')
 	})
@@ -154,10 +172,8 @@ describe('relation import 경로 해석 (FileComponent + resolveRelationImports)
 			{ separateRelationFields: true },
 		)
 
-		const relationsFile = files.find(
-			(f) => f.prismaClass.name === 'CategoryRelations',
-		)
-		const baseFile = files.find((f) => f.prismaClass.name === 'Category')
+		const relationsFile = findFile(files, 'CategoryRelations')
+		const baseFile = findFile(files, 'Category')
 
 		expect(relationsFile.filename).toBe('category_relations.ts')
 		expect(baseFile.filename).toBe('category.ts')
@@ -187,10 +203,8 @@ describe('relation import 경로 해석 (FileComponent + resolveRelationImports)
 			'mongodb',
 		)
 
-		const dealerFile = files.find((f) => f.prismaClass.name === 'Dealer')
-		const addressFile = files.find(
-			(f) => f.prismaClass.name === 'ShippingAddress',
-		)
+		const dealerFile = findFile(files, 'Dealer')
+		const addressFile = findFile(files, 'ShippingAddress')
 
 		expect(addressFile.filename).toBe('shipping_address.ts')
 		expect(findImportFrom(dealerFile, 'ShippingAddress')).toBe(
@@ -210,7 +224,7 @@ describe('preserveDecimal — Prisma 네임스페이스 import', () => {
     `,
 			{ preserveDecimal: true },
 		)
-		const fooFile = files.find((f) => f.prismaClass.name === 'Foo')
+		const fooFile = findFile(files, 'Foo')
 		expect(findImportFrom(fooFile, 'Prisma')).toBe('@prisma/client')
 	})
 
@@ -221,7 +235,7 @@ describe('preserveDecimal — Prisma 네임스페이스 import', () => {
         amt Decimal
       }
     `)
-		const fooFile = files.find((f) => f.prismaClass.name === 'Foo')
+		const fooFile = findFile(files, 'Foo')
 		expect(findImportFrom(fooFile, 'Prisma')).toBeUndefined()
 	})
 })
@@ -237,10 +251,8 @@ describe('useValidation — class-validator import', () => {
     `,
 			{ useValidation: true },
 		)
-		const fooFile = files.find((f) => f.prismaClass.name === 'Foo')
-		const validatorImport = fooFile.imports.find(
-			(i) => i.from === 'class-validator',
-		)
+		const fooFile = findFile(files, 'Foo')
+		const validatorImport = findImport(fooFile, 'class-validator')
 		expect(validatorImport.items).toContain('IsInt')
 		expect(validatorImport.items).toContain('IsString')
 	})
@@ -252,7 +264,7 @@ describe('useValidation — class-validator import', () => {
         name String
       }
     `)
-		const fooFile = files.find((f) => f.prismaClass.name === 'Foo')
+		const fooFile = findFile(files, 'Foo')
 		expect(findImportFrom(fooFile, 'IsInt')).toBeUndefined()
 		expect(fooFile.imports.some((i) => i.from === 'class-validator')).toBe(
 			false,

--- a/src/components/file.component.ts
+++ b/src/components/file.component.ts
@@ -7,13 +7,13 @@ import { Echoable } from '../interfaces/echoable'
 import { ImportComponent } from './import.component'
 
 export class FileComponent implements Echoable {
-	private _dir?: string
-	private _filename?: string
-	private _imports?: ImportComponent[] = []
+	private _dir: string
+	private _filename: string
+	private _imports: ImportComponent[] = []
 	private _prismaClass: ClassComponent
 	private _clientImportPath: string
 	private _useGraphQL: boolean
-	private _prettierOptions: prettier.Options
+	private _prettierOptions: prettier.Options | null
 	static TEMP_PREFIX = '__TEMPORARY_CLASS_PATH__'
 
 	public get dir() {
@@ -53,7 +53,7 @@ export class FileComponent implements Echoable {
 		output: string
 		clientImportPath: string
 		useGraphQL: boolean
-		prettierOptions: prettier.Options
+		prettierOptions: prettier.Options | null
 	}) {
 		const {
 			classComponent,
@@ -63,8 +63,10 @@ export class FileComponent implements Echoable {
 			prettierOptions,
 		} = input
 		this._prismaClass = classComponent
-		this.dir = path.resolve(output)
-		this.filename = `${snakeCase(classComponent.name)}.ts`
+		// assigned through the backing fields rather than the `dir`/`filename` setters so
+		// TypeScript can see them as definitely initialized here.
+		this._dir = path.resolve(output)
+		this._filename = `${snakeCase(classComponent.name)}.ts`
 		this._clientImportPath = clientImportPath
 		this._useGraphQL = useGraphQL
 		this._prettierOptions = prettierOptions
@@ -72,12 +74,7 @@ export class FileComponent implements Echoable {
 	}
 
 	echoImports = () => {
-		return this.imports
-			.reduce((result, importRow) => {
-				result.push(importRow.echo())
-				return result
-			}, [])
-			.join('\r\n')
+		return this.imports.map((importRow) => importRow.echo()).join('\r\n')
 	}
 
 	echo = () => {
@@ -140,7 +137,7 @@ export class FileComponent implements Echoable {
 		// bring in the `Prisma` namespace from the same place the client itself comes from.
 		if (
 			this.prismaClass.fields.some((field) =>
-				field.type.startsWith('Prisma.'),
+				field.type?.startsWith('Prisma.'),
 			)
 		) {
 			this.registerImport('Prisma', this._clientImportPath)

--- a/src/components/import.component.ts
+++ b/src/components/import.component.ts
@@ -23,7 +23,7 @@ export class ImportComponent implements Echoable {
 		dedupePush(this.items, item)
 	}
 
-	getReplacePath(classToPath: Record<string, string>): string {
+	getReplacePath(classToPath: Record<string, string>): string | null {
 		if (this.from.includes(FileComponent.TEMP_PREFIX) === false) {
 			return null
 		}

--- a/src/convertor.property.spec.ts
+++ b/src/convertor.property.spec.ts
@@ -219,11 +219,7 @@ describe('PrismaConvertor#getPrimitiveMapTypeFromDMMF (property-based)', () => {
 			fc.property(allScalarTypes, fc.boolean(), (type, isList) => {
 				const field = convertField({ type, isList })
 				expect(field.type).toBeTruthy()
-				if (isList) {
-					expect(field.type.endsWith('[]')).toBe(true)
-				} else {
-					expect(field.type.endsWith('[]')).toBe(false)
-				}
+				expect(field.type?.endsWith('[]')).toBe(isList)
 			}),
 		)
 	})

--- a/src/convertor.ts
+++ b/src/convertor.ts
@@ -137,8 +137,13 @@ export interface ConvertModelInput {
 
 export class PrismaConvertor {
 	static instance: PrismaConvertor
-	private _config: PrismaClassGeneratorConfig
-	private _dmmf: DMMF.Document
+	// injected through the setters below immediately after getInstance()/new (see
+	// PrismaClassGenerator#buildFileComponents) rather than passed to the constructor, so
+	// there is nothing sensible to initialize them to here. Defaulting `_config` to `{}`
+	// would be worse than leaving it unset: a forgotten `convertor.config = ...` would then
+	// silently generate output with every option off instead of failing loudly.
+	private _config!: PrismaClassGeneratorConfig
+	private _dmmf!: DMMF.Document
 
 	public get dmmf(): DMMF.Document {
 		return this._dmmf
@@ -164,13 +169,16 @@ export class PrismaConvertor {
 		return PrismaConvertor.instance
 	}
 
+	// `undefined` for every field that isn't a Prisma scalar (relations, enums, composite
+	// types) -- callers branch on that to decide whether the field needs an explicit
+	// `type: () => X` reference instead of a primitive TS type.
 	getPrimitiveMapTypeFromDMMF = (
 		dmmfField: DMMF.Field,
-	): PrimitiveMapTypeValues => {
+	): PrimitiveMapTypeValues | undefined => {
 		if (typeof dmmfField.type !== 'string') {
 			return 'unknown'
 		}
-		return primitiveMapType[dmmfField.type]
+		return primitiveMapType[dmmfField.type as DefaultPrismaFieldType]
 	}
 
 	extractTypeGraphQLDecoratorFromField = (
@@ -427,20 +435,16 @@ export class PrismaConvertor {
 	}
 
 	getClass = (input: ConvertModelInput): ClassComponent => {
-		/** options */
-		const options = Object.assign(
-			{
-				extractRelationFields: null,
-				useGraphQL: false,
-			},
-			input,
-		)
+		// `extractRelationFields` stays tri-state on purpose: `true` keeps only relation
+		// fields, `false` keeps only non-relation ones, and unset keeps everything (see the
+		// filter below) -- that's what makes one model produce both a base class and a
+		// *Relations class under separateRelationFields.
 		const {
 			model,
-			extractRelationFields = null,
+			extractRelationFields,
 			postfix,
-			useGraphQL,
-		} = options
+			useGraphQL = false,
+		} = input
 
 		/** set class name */
 		let className = model.name
@@ -589,7 +593,7 @@ export class PrismaConvertor {
 	convertField = (dmmfField: DMMF.Field): FieldComponent => {
 		const field = new FieldComponent({
 			name: dmmfField.name,
-			useUndefinedDefault: this._config.useUndefinedDefault,
+			useUndefinedDefault: !!this._config.useUndefinedDefault,
 		})
 		const type = this.getPrimitiveMapTypeFromDMMF(dmmfField)
 

--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -1,4 +1,8 @@
-import { PrismaClassGeneratorOptions, REPO_URL } from './generator'
+import {
+	PrismaClassGeneratorOptions,
+	PrismaClassGeneratorOptionsKeys,
+	REPO_URL,
+} from './generator'
 import { log } from './util'
 
 export class GeneratorFormatNotValidError extends Error {
@@ -9,9 +13,14 @@ export class GeneratorFormatNotValidError extends Error {
 
 export class GeneratorPathNotExists extends Error {}
 
-export const handleGenerateError = (e: Error) => {
+// `unknown` rather than `Error`: this is called straight from a `catch` block (see index.ts),
+// and JS lets anything be thrown -- narrowing is done below instead of assumed by the caller.
+export const handleGenerateError = (e: unknown) => {
 	if (e instanceof GeneratorFormatNotValidError) {
-		const options = Object.keys(PrismaClassGeneratorOptions).map((key) => {
+		const optionNames = Object.keys(
+			PrismaClassGeneratorOptions,
+		) as PrismaClassGeneratorOptionsKeys[]
+		const options = optionNames.map((key) => {
 			const value = PrismaClassGeneratorOptions[key]
 			return `\t${key} = (${value.defaultValue}) <- [${value.desc}]`
 		})
@@ -39,7 +48,7 @@ export const handleGenerateError = (e: Error) => {
 	// coding agent (Claude Code and similar), so "open an issue" alone tends to go nowhere —
 	// spelling out that a PR is just as welcome, with a link straight to the file to fix and
 	// how to verify it, gives an agent enough to actually act on instead of just reporting.
-	log(`Unexpected error: ${e.message}`)
+	log(`Unexpected error: ${e instanceof Error ? e.message : String(e)}`)
 	console.error(e)
 	log(
 		[

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -133,10 +133,15 @@ export interface PrismaClassGeneratorConfig {
 
 export class PrismaClassGenerator {
 	static instance: PrismaClassGenerator
-	_options: GeneratorOptions
-	_prettierOptions: prettier.Options
-	rootPath: string
-	clientPath: string
+	// `_options` is set through the setter (from the constructor or by tests that build an
+	// instance with Object.create), `rootPath`/`clientPath` by setPrismaClientPath() at the
+	// start of run() -- none of them can be initialized where they're declared.
+	_options!: GeneratorOptions
+	rootPath!: string
+	clientPath!: string | null
+	// null is prettier's own "no config file found anywhere" answer, kept as-is rather than
+	// normalized to {} so callers can still tell the two apart.
+	_prettierOptions: prettier.Options | null = null
 
 	constructor(options?: GeneratorOptions) {
 		if (options) {
@@ -201,8 +206,10 @@ export class PrismaClassGenerator {
 	setPrismaClientPath(): void {
 		const { otherGenerators, schemaPath } = this.options
 
-		const clientGenerator = otherGenerators.find((g) =>
-			PRISMA_CLIENT_GENERATOR_PROVIDERS.includes(g.provider.value),
+		const clientGenerator = otherGenerators.find(
+			(g) =>
+				g.provider.value !== null &&
+				PRISMA_CLIENT_GENERATOR_PROVIDERS.includes(g.provider.value),
 		)
 		if (!clientGenerator) {
 			throw new GeneratorPathNotExists(
@@ -213,7 +220,7 @@ export class PrismaClassGenerator {
 		}
 
 		this.rootPath = schemaPath.replace('/prisma/schema.prisma', '')
-		this.clientPath = clientGenerator.output.value
+		this.clientPath = clientGenerator.output?.value ?? null
 	}
 
 	async run(): Promise<void> {
@@ -222,16 +229,20 @@ export class PrismaClassGenerator {
 		const config = this.getConfig()
 		this.setPrismaClientPath()
 
+		// getConfig() fills in every option from PrismaClassGeneratorOptions, so this can only
+		// fall back for a hand-built config -- match dryRun's own declared default if it does.
+		const dryRun = config.dryRun ?? true
+
 		const files = this.buildFileComponents(config, output)
 		resolveRelationImports(files)
 
-		await Promise.all(files.map((fileRow) => fileRow.write(config.dryRun)))
+		await Promise.all(files.map((fileRow) => fileRow.write(dryRun)))
 
 		if (config.makeIndexFile) {
-			await this.writeIndexFile(files, output, config.dryRun)
+			await this.writeIndexFile(files, output, dryRun)
 		}
 
-		if (config.dryRun) {
+		if (dryRun) {
 			this.logDryRunReminder(files.length)
 		}
 	}
@@ -312,8 +323,20 @@ export class PrismaClassGenerator {
 	getConfig(): PrismaClassGeneratorConfig {
 		const config = this.options.generator.config
 
-		const result: PrismaClassGeneratorConfig = {}
-		for (const optionName in PrismaClassGeneratorOptions) {
+		// built through a string-keyed record and cast once at the end: indexing
+		// PrismaClassGeneratorConfig with a *union* of keys narrows the assignable type to the
+		// intersection of every option's type (i.e. nothing), so a per-key assignment loop
+		// can't be expressed against that interface directly. Every key written here comes
+		// from PrismaClassGeneratorOptions, which the interface mirrors one-for-one.
+		const result: Record<
+			string,
+			boolean | number | string | string[] | undefined
+		> = {}
+		const optionNames = Object.keys(
+			PrismaClassGeneratorOptions,
+		) as PrismaClassGeneratorOptionsKeys[]
+
+		for (const optionName of optionNames) {
 			const { defaultValue } = PrismaClassGeneratorOptions[optionName]
 			result[optionName] = defaultValue
 
@@ -329,6 +352,6 @@ export class PrismaClassGenerator {
 			}
 		}
 
-		return result
+		return result as PrismaClassGeneratorConfig
 	}
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -52,12 +52,13 @@ export const log = (src: string) => {
 }
 
 export const parseBoolean = (value: unknown): boolean => {
-	if (['true', 'false'].includes(value.toString()) === false) {
+	const stringified = String(value)
+	if (['true', 'false'].includes(stringified) === false) {
 		throw new GeneratorFormatNotValidError(
 			`parseBoolean failed : "${value}" is not boolean type`,
 		)
 	}
-	return value.toString() === 'true'
+	return stringified === 'true'
 }
 
 export const parseNumber = (value: unknown): number => {
@@ -140,9 +141,12 @@ export const writeTSFile = (
 	fs.writeFileSync(fullPath, content)
 }
 
+// `null` is what prettier's own resolveConfig() returns when a project has no prettier
+// config at all (see PrismaClassGenerator#resolvePrettierOptions), so it's accepted here
+// rather than normalized upstream -- spreading it is already a no-op.
 export const prettierFormat = (
 	content: string,
-	options: Options = {},
+	options: Options | null = {},
 ): Promise<string> => {
 	return format(content, { ...options, parser: 'typescript' })
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,7 @@
 		// ts-jest transpiles one file at a time and needs to know it can do that safely under
 		// the node16 module kind — see ts-jest's TS151002 warning.
 		"isolatedModules": true,
-		// TypeScript 6+ defaults "strict" to true when omitted. This codebase predates strict
-		// mode and isn't strict-clean (~60 errors: strictNullChecks, noImplicitAny,
-		// strictPropertyInitialization). Pinning it off keeps current behavior; adopting strict
-		// mode is a real, separate undertaking, not a side effect of a tsconfig modernization.
-		"strict": false,
+		"strict": true,
 		"allowSyntheticDefaultImports": true,
 		"paths": {
 			"@src/*": ["./src/*"]


### PR DESCRIPTION
Two independent changes, one commit each.

## 1. `ci:` record the actual change-case 5.x compatibility result

The dependabot ignore rule for `change-case` said "untested / unverified". It's now verified, empirically:

| Node | `require('change-case@5.4.4')` |
|---|---|
| 18.20.8 | ❌ `ERR_REQUIRE_ESM` |
| 20.19.4 | ✅ |
| 22.23.1 | ✅ |

v5 (5.0.0 → 5.4.4) is pure ESM — `"type": "module"` with only an `import` condition in `exports` — and this package publishes CommonJS. `require(ESM)` landed in Node 22.12 and was **backported to 20.19**, so the only thing blocking the bump is this repo's `engines.node: >=18` floor, not behavior.

Behavior was checked too: v4 vs v5 `snakeCase` diffed over 20 Prisma-style identifiers (`ABCModel`, `HTTPRequest`, `User2Post`, `Model_V2`, `OAuthToken`, `_Private`, …) → **zero differences**, so generated filenames would not change. The rule can be dropped outright the day the Node floor moves to `>=20.19`; the comment now says that.

No code change, comment only.

## 2. `refactor:` adopt TypeScript strict mode

`tsconfig.json` had `strict: false` pinned with a comment calling strict adoption a separate undertaking. This is that undertaking: **58 errors in `src/` + 31 in the specs → 0**, with the golden fixture snapshots byte-identical. **Generated output does not change.**

Most of the work was making types admit what the code already did at runtime:

- `getPrimitiveMapTypeFromDMMF()` returns `undefined` for every non-scalar field (relations, enums, composite types) and callers already branch on that — the return type now says so.
- `ImportComponent#getReplacePath()` returns `null` for a non-placeholder import.
- `prettierOptions` is `null` when prettier finds no config file anywhere — which `generator.spec.ts` already asserts — so it's typed `Options | null` end to end rather than normalized to `{}`, which would have changed that documented behavior.
- `handleGenerateError()` takes `unknown`: it's called straight from a `catch` block, and JS lets anything be thrown.
- `FieldComponent`'s `nullable`/`nonNullableAssertion`/`preserveDefaultNullable` were declared `boolean` but only ever assigned when switched on, so they could be `undefined`; they now default to `false`, which is exactly how `echo()` already treated them.
- `getClass()`'s `Object.assign`-based option merge intersected `null` with `boolean | undefined` to `never`, which collapsed `model` to `never` as well. Replaced with plain destructuring; `extractRelationFields` stays tri-state.

### Conventions adopted (documented in CLAUDE.md)

- Definite assignment (`!`) is reserved for singleton state injected through setters right after construction (`PrismaConvertor._dmmf/_config`, `PrismaClassGenerator._options/rootPath/clientPath`). Not a general escape hatch for "might be undefined".
- `PrismaClassGeneratorConfig` stays all-optional so specs can build partial configs; call sites needing a concrete value supply the same default `PrismaClassGeneratorOptions` declares (e.g. `run()`'s `config.dryRun ?? true`). `getConfig()` builds through a string-keyed record and casts once — indexing the interface with a *union* of keys narrows the assignable type to nothing, so a per-key loop can't be written against it directly.

### Worth knowing for future changes

ts-jest type-checks the specs with this same tsconfig, so strictness breaks the **test run**, not just `npm run typecheck`. The 28 possibly-undefined `.find()` results in `file.component.spec.ts` are handled by `findFile`/`findImport` helpers that throw a named error rather than non-null assertions, so a broken lookup reports what it couldn't find instead of "cannot read properties of undefined".

## Verification

`npm run typecheck`, `npm run lint`, `npm test` (188 tests, 6 snapshots), `npm run build` — all pass locally. Snapshot diff is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)