### PR TITLE
refactor: drop the change-case runtime dependency

### DIFF
--- a/.changeset/tall-donkeys-smile.md
+++ b/.changeset/tall-donkeys-smile.md
@@ -1,0 +1,11 @@
+---
+'prisma-class-generator': patch
+---
+
+Drop the `change-case` runtime dependency. It was used for exactly one function (`snakeCase`, on
+Prisma model/type names), and pulled in 16 packages transitively; its 5.x line is ESM-only, which
+this CommonJS build can't consume on Node 18. That one function now lives in `util.ts` as
+`toSnakeCase`, transcribed from change-case@4 and verified against it over 150k property-generated
+inputs — Prisma identifiers, messy ASCII and arbitrary unicode — with zero differences, so no
+generated filename or import path changes. Runtime dependencies are down to three:
+`@prisma/generator-helper`, `@prisma/internals` and `prettier`.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,17 +48,6 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@changesets/changelog-github'
         update-types: ['version-update:semver-major']
-      # change-case 5.x is ESM-only ("type": "module", exports expose only an `import`
-      # condition) and this package is published as CommonJS, so `require('change-case')`
-      # throws ERR_REQUIRE_ESM -- verified by actually installing 5.4.4 and requiring it under
-      # node 18.20.8 (fails), 20.19.4 (works) and 22.23.1 (works); require(ESM) landed in
-      # 22.12 and was backported to 20.19. So the only thing blocking this bump is the
-      # `engines.node: >=18` floor, not behavior: v4 and v5 `snakeCase` were also diffed over
-      # 20 Prisma-style identifiers (ABCModel, HTTPRequest, User2Post, Model_V2, ...) with
-      # zero differences, so generated filenames would not change. Drop this ignore rule as
-      # soon as this repo's Node floor moves to >=20.19.
-      - dependency-name: 'change-case'
-        update-types: ['version-update:semver-major']
       # eslint 10.x and @eslint/js 10.x both require Node >=20.19 (9.x supports 18) -- a
       # grouped dev-dependencies PR bumping both broke the node 18/20/22 CI legs the same day
       # ESLint was first added.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,13 @@ src/
 This is deliberately a string-template pipeline, not an AST transform. It's simple to reason
 about at this size — don't reach for ts-morph or similar without a concrete reason.
 
+Runtime `dependencies` are deliberately kept to three (`@prisma/generator-helper`,
+`@prisma/internals`, `prettier`). `util.ts`'s `toSnakeCase` used to be `change-case`'s
+`snakeCase`, inlined once that package's only remaining pull was one function and its 5.x line
+went ESM-only; its output is a **compatibility contract**, not a style choice — it produces both
+the generated filename and the import path other generated files reach it by, so changing it
+renames every existing user's generated files. `util.spec.ts` pins the cases that matter.
+
 `PrismaClassGenerator` and `PrismaConvertor` are singletons (`static instance` /
 `getInstance()`) — fine for a CLI that runs once per process. `FileComponent`, however, takes
 `clientImportPath`/`useGraphQL`/`prettierOptions` as explicit constructor params rather than

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
 	"dependencies": {
 		"@prisma/generator-helper": "^7.9.1",
 		"@prisma/internals": "^7.9.1",
-		"change-case": "^4.1.2",
 		"prettier": "3.9.6"
 	},
 	"devDependencies": {

--- a/src/components/file.component.ts
+++ b/src/components/file.component.ts
@@ -1,8 +1,12 @@
-import { snakeCase } from 'change-case'
 import * as prettier from 'prettier'
 import { ClassComponent } from './class.component'
 import * as path from 'path'
-import { getRelativeTSPath, prettierFormat, writeTSFile } from '../util'
+import {
+	getRelativeTSPath,
+	prettierFormat,
+	toSnakeCase,
+	writeTSFile,
+} from '../util'
 import { Echoable } from '../interfaces/echoable'
 import { ImportComponent } from './import.component'
 
@@ -66,7 +70,7 @@ export class FileComponent implements Echoable {
 		// assigned through the backing fields rather than the `dir`/`filename` setters so
 		// TypeScript can see them as definitely initialized here.
 		this._dir = path.resolve(output)
-		this._filename = `${snakeCase(classComponent.name)}.ts`
+		this._filename = `${toSnakeCase(classComponent.name)}.ts`
 		this._clientImportPath = clientImportPath
 		this._useGraphQL = useGraphQL
 		this._prettierOptions = prettierOptions
@@ -162,7 +166,7 @@ export class FileComponent implements Echoable {
 				// must match the snake_case filename FileComponent itself generates below,
 				// otherwise multi-word MongoDB composite type names (e.g. ShippingAddress)
 				// import from a path that doesn't match the file actually written to disk.
-				this.registerImport(type, './' + snakeCase(type))
+				this.registerImport(type, './' + toSnakeCase(type))
 			})
 		}
 	}

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -14,6 +14,7 @@ import {
 	prettierFormat,
 	toArray,
 	toImportPath,
+	toSnakeCase,
 	uniquify,
 	wrapArrowFunction,
 	wrapQuote,
@@ -27,6 +28,43 @@ describe('capitalizeFirst', () => {
 
 	it('빈 문자열은 그대로 반환한다', () => {
 		expect(capitalizeFirst('')).toBe('')
+	})
+})
+
+// These expectations are change-case@4's `snakeCase` output, captured when that dependency was
+// replaced by toSnakeCase (parity verified over 150k property-generated inputs at the time).
+// They are effectively a compatibility contract, not a style preference: the value feeds both
+// the generated filename and the import path other generated files use to reach it, so a change
+// here silently renames every user's generated files.
+describe('toSnakeCase', () => {
+	it.each([
+		['User', 'user'],
+		['UserProfile', 'user_profile'],
+		['ShippingAddress', 'shipping_address'],
+		['CategoryRelations', 'category_relations'],
+		// acronyms stay whole rather than splitting per letter
+		['HTTPRequest', 'http_request'],
+		['ABCModel', 'abc_model'],
+		['XMLHttpRequest', 'xml_http_request'],
+		['UserID', 'user_id'],
+		['ID', 'id'],
+		// a digit ends a token, an uppercase letter after it starts a new one
+		['User2Post', 'user2_post'],
+		['Order2', 'order2'],
+		['Foo1Bar2', 'foo1_bar2'],
+		['v2Model', 'v2_model'],
+		// underscores are separators, not content -- an already-snake_cased name round-trips
+		['user_profile', 'user_profile'],
+		['Model_V2', 'model_v2'],
+		['_Private', 'private'],
+		// single letters and degenerate input
+		['A', 'a'],
+		['aB', 'a_b'],
+		['AAA', 'aaa'],
+		['', ''],
+		['___', ''],
+	])('%s -> %s', (input, expected) => {
+		expect(toSnakeCase(input)).toBe(expected)
 	})
 })
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,6 +10,40 @@ export const capitalizeFirst = (src: string) => {
 	return src.charAt(0).toUpperCase() + src.slice(1)
 }
 
+// Split on the two casing boundaries change-case's `noCase` uses: lower/digit -> upper
+// (`userId` -> `user|Id`) and upper -> upper+lower, which keeps acronyms whole
+// (`HTTPRequest` -> `HTTP|Request`, not `H|T|T|P|Request`).
+const SNAKE_CASE_SPLIT_PATTERNS = [/([a-z0-9])([A-Z])/g, /([A-Z])([A-Z][a-z])/g]
+// everything that isn't an ASCII letter or digit is a separator, including the `_` in a name
+// that is already snake_cased
+const SNAKE_CASE_STRIP_PATTERN = /[^A-Z0-9]+/gi
+const SNAKE_CASE_TOKEN_MARKER = '\0'
+
+/**
+ * snake_cases a Prisma model/type name for use as a generated filename and as the import path
+ * other generated files reference it by — the two must agree exactly, so this has exactly one
+ * definition (see FileComponent).
+ *
+ * This is a transcription of `change-case@4`'s `snakeCase`, which this package depended on
+ * until it became the only thing standing between the build and a pure-ESM dependency. Parity
+ * was verified against the real change-case@4 over 150k property-generated inputs (Prisma
+ * identifiers, messy ASCII, arbitrary unicode) with zero differences, so switching to it can't
+ * rename anyone's generated files.
+ */
+export const toSnakeCase = (value: string): string => {
+	const marked = SNAKE_CASE_SPLIT_PATTERNS.reduce(
+		(result, pattern) =>
+			result.replace(pattern, `$1${SNAKE_CASE_TOKEN_MARKER}$2`),
+		value,
+	).replace(SNAKE_CASE_STRIP_PATTERN, SNAKE_CASE_TOKEN_MARKER)
+
+	return marked
+		.split(SNAKE_CASE_TOKEN_MARKER)
+		.filter((token) => token.length > 0)
+		.map((token) => token.toLowerCase())
+		.join('_')
+}
+
 // Import specifiers must always use forward slashes -- on Windows, path.relative() returns
 // `\`-separated paths, which would otherwise end up embedded verbatim in a generated
 // `import ... from '..\foo'`, an invalid module specifier.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1839,14 +1839,6 @@ callsites@^3.0.0, callsites@^3.1.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-camel-case@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
-  integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
-  dependencies:
-    pascal-case "^3.1.2"
-    tslib "^2.0.3"
-
 camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -1861,15 +1853,6 @@ caniuse-lite@^1.0.30001809:
   version "1.0.30001809"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz#e6cf71f14ddfe008f114dd2a846923be3c03a07b"
   integrity sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==
-
-capital-case@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.4.tgz#9d130292353c9249f6b00fa5852bee38a717e669"
-  integrity sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-    upper-case-first "^2.0.2"
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -1887,24 +1870,6 @@ chalk@^4.0.0, chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
-
-change-case@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/change-case/-/change-case-4.1.2.tgz#fedfc5f136045e2398c0410ee441f95704641e12"
-  integrity sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==
-  dependencies:
-    camel-case "^4.1.2"
-    capital-case "^1.0.4"
-    constant-case "^3.0.4"
-    dot-case "^3.0.4"
-    header-case "^2.0.4"
-    no-case "^3.0.4"
-    param-case "^3.0.4"
-    pascal-case "^3.1.2"
-    path-case "^3.0.4"
-    sentence-case "^3.0.4"
-    snake-case "^3.0.4"
-    tslib "^2.0.3"
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -2002,15 +1967,6 @@ consola@^3.2.3, consola@^3.4.0:
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/consola/-/consola-3.4.2.tgz#5af110145397bb67afdab77013fdc34cae590ea7"
   integrity sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==
-
-constant-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-3.0.4.tgz#3b84a9aeaf4cf31ec45e6bf5de91bdfb0589faf1"
-  integrity sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-    upper-case "^2.0.2"
 
 convert-source-map@^2.0.0:
   version "2.0.0"
@@ -2110,14 +2066,6 @@ dir-glob@^3.0.1:
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
-
-dot-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
-  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
 
 dotenv@^16.6.1:
   version "16.6.1"
@@ -2635,14 +2583,6 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
-
-header-case@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/header-case/-/header-case-2.0.4.tgz#5a42e63b55177349cf405beb8d775acabb92c063"
-  integrity sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==
-  dependencies:
-    capital-case "^1.0.4"
-    tslib "^2.0.3"
 
 html-escaper@^2.0.0:
   version "2.0.2"
@@ -3301,13 +3241,6 @@ lodash.startcase@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.startcase/-/lodash.startcase-4.4.0.tgz#9436e34ed26093ed7ffae1936144350915d9add8"
   integrity sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==
 
-lower-case@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
-  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
-  dependencies:
-    tslib "^2.0.3"
-
 lru-cache@^10.2.0:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
@@ -3432,14 +3365,6 @@ neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-no-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
-  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
-  dependencies:
-    lower-case "^2.0.2"
-    tslib "^2.0.3"
 
 node-fetch-native@^1.6.6:
   version "1.6.7"
@@ -3577,14 +3502,6 @@ package-manager-detector@^0.2.0:
   dependencies:
     quansync "^0.2.7"
 
-param-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
-  integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
-  dependencies:
-    dot-case "^3.0.4"
-    tslib "^2.0.3"
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -3601,22 +3518,6 @@ parse-json@^5.2.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
-
-pascal-case@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
-  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-
-path-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/path-case/-/path-case-3.0.4.tgz#9168645334eb942658375c56f80b4c0cb5f82c6f"
-  integrity sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==
-  dependencies:
-    dot-case "^3.0.4"
-    tslib "^2.0.3"
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -3887,15 +3788,6 @@ semver@^7.5.4, semver@^7.7.2, semver@^7.7.3, semver@^7.8.5:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
   integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
-sentence-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
-  integrity sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==
-  dependencies:
-    no-case "^3.0.4"
-    tslib "^2.0.3"
-    upper-case-first "^2.0.2"
-
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
@@ -3927,14 +3819,6 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
-
-snake-case@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"
-  integrity sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
-  dependencies:
-    dot-case "^3.0.4"
-    tslib "^2.0.3"
 
 source-map-support@0.5.13:
   version "0.5.13"
@@ -4156,11 +4040,6 @@ ts-node@^10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tslib@^2.0.3:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
-
 tslib@^2.4.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
@@ -4260,20 +4139,6 @@ update-browserslist-db@^1.3.0:
   dependencies:
     escalade "^3.2.0"
     picocolors "^1.1.1"
-
-upper-case-first@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-2.0.2.tgz#992c3273f882abd19d1e02894cc147117f844324"
-  integrity sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==
-  dependencies:
-    tslib "^2.0.3"
-
-upper-case@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-2.0.2.tgz#d89810823faab1df1549b7d97a76f8662bae6f7a"
-  integrity sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==
-  dependencies:
-    tslib "^2.0.3"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Follow-up to #100, which verified that `change-case@5` is pure ESM and therefore unusable from this CommonJS build while `engines.node` stays at `>=18`. Rather than carry a permanent dependabot ignore rule for a package doing one string transform, this removes the dependency.

## What it was doing

Exactly one function — `snakeCase`, applied to Prisma model and composite-type names in `FileComponent` (two call sites). It brought **16 packages** transitively:

```
camel-case, capital-case, change-case, constant-case, dot-case, header-case,
lower-case, no-case, param-case, pascal-case, path-case, sentence-case,
snake-case, tslib, upper-case, upper-case-first
```

Runtime `dependencies` are now down to three: `@prisma/generator-helper`, `@prisma/internals`, `prettier`.

## Correctness

`util.ts`'s new `toSnakeCase` is a transcription of change-case@4's own `noCase` pipeline: two casing-boundary split patterns (`lower|digit → upper`, and `upper → upper+lower` so acronyms stay whole), a non-alphanumeric strip, lowercase, join.

Parity with the **real change-case@4** was verified in a scratch harness before removing it:

| input space | runs | mismatches |
|---|---|---|
| Prisma-shaped identifiers `[A-Za-z][A-Za-z0-9_]*` | 50,000 | 0 |
| messy ASCII + unicode punctuation | 50,000 | 0 |
| arbitrary unicode strings | 50,000 | 0 |
| hand-picked edge cases | 41 | 0 |

**150,041 comparisons, zero differences.** The golden fixture snapshots are also unchanged, so no generated filename or import path moves for any existing user.

## Why the tests look the way they do

`util.spec.ts` pins 21 cases as a **compatibility contract**, not a style preference — the comment says so. This value produces both the generated filename *and* the import path other generated files use to reach it, so changing it would silently rename every existing user's generated files. The pinned cases cover the three behaviours that are easy to get wrong when reimplementing: acronyms staying whole (`HTTPRequest` → `http_request`, not `h_t_t_p_request`), digits ending a token (`User2Post` → `user2_post`), and underscores being separators so an already-snake_cased name round-trips.

## Also

- Removes the now-dead `change-case` ignore rule from `.github/dependabot.yml`.
- CLAUDE.md notes the three-dependency budget and that `toSnakeCase`'s output is a contract.

## Verification

`npm run typecheck`, `npm run lint`, `npm test` (209 tests — 188 + 21 new, 6 snapshots), `npm run build` all pass. `yarn.lock` diff is 135 deletions and zero additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)