### PR TITLE
refactor: slim the package (-28MB dep, -29% tarball) and add packaging guards

### DIFF
--- a/.changeset/eighty-jars-run.md
+++ b/.changeset/eighty-jars-run.md
@@ -1,0 +1,14 @@
+---
+'prisma-class-generator': patch
+---
+
+Cut what this package costs to install. `@prisma/internals` moves to devDependencies: the specs
+still use its `getDMMF`, but it installs 28MB, `prisma` itself doesn't depend on it (so it never
+dedupes with a project's existing install), and the generator only needed two things from it —
+`parseEnvValue` and `logger.info` — both now transcribed into `util.ts` with their behaviour and
+output unchanged. Sourcemaps are also no longer published: `files` ships only `dist`, so their
+`sources: ["../src/*.ts"]` pointed at files that were never in the tarball.
+
+Runtime dependencies are now `@prisma/generator-helper` and `prettier`. The published tarball is
+29% smaller (130.8kB → 93.0kB unpacked), and `@prisma/internals`' 28MB is gone from every install.
+`package.json` also declares `"type": "commonjs"` explicitly so Node doesn't have to detect it.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,14 @@ updates:
       # the same grouped PR as the eslint bump above.
       - dependency-name: 'cross-env'
         update-types: ['version-update:semver-major']
+      # lint-staged 16.x needs Node >=20.17 and 17.x needs >=22.22.1 (15.x supports 18.12+),
+      # confirmed via npm view before adding it. husky has no 10.x yet, but it's the same
+      # class of local-tooling dependency, so guard the major pre-emptively rather than find
+      # out from a red CI run.
+      - dependency-name: 'lint-staged'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'husky'
+        update-types: ['version-update:semver-major']
     commit-message:
       prefix: 'chore'
       include: 'scope'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches: [main]
 
+# husky's git hooks are a local developer convenience only -- they can't run in CI anyway
+# (Actions doesn't commit), and without this every `yarn install` would still spend a step
+# installing them. HUSKY=0 makes the `prepare` script a no-op instead. CI, not the hook, is
+# the source of truth: every check the hook runs is also run below, on the full tree.
+env:
+  HUSKY: 0
+
 jobs:
   build-and-test:
     name: build & test (node ${{ matrix.node-version }})
@@ -24,6 +31,10 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: npm run typecheck
       - run: npm run lint
+      # eslint-config-prettier *disables* formatting rules rather than checking them, so
+      # `npm run lint` alone lets an unformatted file through -- this is the only thing that
+      # actually enforces .prettierrc.json on CI.
+      - run: npm run format:check
       - run: npm run build
       - run: npm test
 
@@ -58,6 +69,29 @@ jobs:
       - run: npm run typecheck
       - run: npm run build
       - run: npm test
+
+  packaging:
+    # Everything above validates the *repo*. This validates the artifact npm would actually
+    # receive: publint checks package.json's entry points against the packed file list, and
+    # the smoke test installs the tarball into an empty project and drives a real
+    # `prisma generate` through it by provider name. That combination is what catches a bad
+    # `files`/`bin` field, or a runtime import of something that's only a devDependency --
+    # none of which the repo's own fully-populated node_modules can reveal.
+    name: packaging (tarball)
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+      - run: npm run build
+      - run: npm run lint:package
+      - run: npm run verify:packed
 
   prisma-compat:
     name: prisma ${{ matrix.prisma-version }} (${{ matrix.client-provider }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+# See ci.yml -- husky's git hooks are local-only. This also keeps `prepare` from running
+# husky during the publish step, where there is nothing for it to install.
+env:
+  HUSKY: 0
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ src/_gen/prisma-class/*.ts
 
 # internal-only planning/strategy docs — not meant for the public repo
 REVIEW.md
+# npm pack / yarn pack / publint leave these behind
+*.tgz

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+# Local-only fast feedback: format + autofix just the staged TypeScript, nothing more.
+# CI stays the source of truth (it runs format:check, lint, typecheck, tests, publint and a
+# packed-tarball smoke test), so this hook is deliberately cheap enough to never be the reason
+# someone reaches for --no-verify. It never runs in CI: every workflow sets HUSKY=0, which
+# makes the `prepare` script a no-op there.
+npx lint-staged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,15 @@ src/
 This is deliberately a string-template pipeline, not an AST transform. It's simple to reason
 about at this size — don't reach for ts-morph or similar without a concrete reason.
 
-Runtime `dependencies` are deliberately kept to three (`@prisma/generator-helper`,
-`@prisma/internals`, `prettier`). `util.ts`'s `toSnakeCase` used to be `change-case`'s
+Runtime `dependencies` are deliberately kept to two (`@prisma/generator-helper`, `prettier`) —
+everything a user installs to run this generator. `@prisma/internals` is a **devDependency on
+purpose**: the specs use its `getDMMF`, but it installs 28MB and `prisma` itself doesn't depend
+on it (so it never dedupes), and the only two things the generator needed from it —
+`parseEnvValue` and `logger.info` — are transcribed into `util.ts`. Before adding any runtime
+import, check whether it's really worth what it costs a user; `npm run verify:packed` is what
+catches a runtime import that only resolves because this repo has everything installed.
+
+`util.ts`'s `toSnakeCase` used to be `change-case`'s
 `snakeCase`, inlined once that package's only remaining pull was one function and its 5.x line
 went ESM-only; its output is a **compatibility contract**, not a style choice — it produces both
 the generated filename and the import path other generated files reach it by, so changing it
@@ -45,6 +52,14 @@ seeding global state in every spec file.
 ```
 npm run build          # rm -rf dist && tsc — always clean-builds, never leaves stale output
 npm test                # jest
+npm run format:check    # what CI enforces — `npm run lint` can't catch formatting, because
+                         # eslint-config-prettier *disables* those rules rather than checking them
+npm run lint:package    # publint against the packed tarball. `--pack npm` is not optional:
+                         # publint mis-parses Yarn Classic's tarballs (bare directory entries)
+                         # and reports every entry point as missing from `files`
+npm run verify:packed   # pack, install the tarball into an empty project, run a real
+                         # `prisma generate` through it by provider name — the only check that
+                         # sees a bad files/bin field or a runtime import of a devDependency
 npm run generate:*      # regenerate a fixture under prisma/*.prisma (postgresql, mysql,
                          # mongodb, mssql, sqlite, cockroachdb) — useful for manually eyeballing
                          # output, but note prisma-client-js's auto-install can add

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "0.6.5",
 	"description": "Prisma generator that emits TypeScript classes decorated for @nestjs/swagger, class-validator, and TypeGraphQL — DTO/entity classes generated straight from schema.prisma.",
 	"main": "dist/index.js",
+	"type": "commonjs",
 	"license": "MIT",
 	"keywords": [
 		"prisma",
@@ -25,11 +26,13 @@
 	"homepage": "https://github.com/kimjbstar/prisma-class-generator",
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/kimjbstar/prisma-class-generator.git"
+		"url": "git+https://github.com/kimjbstar/prisma-class-generator.git"
 	},
 	"scripts": {
 		"format": "prettier --write \"src/**/*.ts\"",
+		"format:check": "prettier --check \"src/**/*.ts\"",
 		"lint": "eslint src",
+		"lint:package": "publint --pack npm",
 		"test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
 		"test:coverage": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage",
 		"typecheck": "tsc --noEmit",
@@ -45,7 +48,9 @@
 		"generate:mongodb": "prisma generate --schema prisma/mongodb.prisma",
 		"generate:mssql": "prisma generate --schema prisma/mssql.prisma",
 		"generate:sqlite": "prisma generate --schema prisma/sqlite.prisma",
-		"generate:cockroachdb": "prisma generate --schema prisma/cockroachdb.prisma"
+		"generate:cockroachdb": "prisma generate --schema prisma/cockroachdb.prisma",
+		"verify:packed": "bash scripts/verify-packed-tarball.sh",
+		"prepare": "husky || true"
 	},
 	"bin": {
 		"prisma-class-generator": "dist/bin.js"
@@ -62,7 +67,6 @@
 	},
 	"dependencies": {
 		"@prisma/generator-helper": "^7.9.1",
-		"@prisma/internals": "^7.9.1",
 		"prettier": "3.9.6"
 	},
 	"devDependencies": {
@@ -70,6 +74,7 @@
 		"@changesets/cli": "2.31.1",
 		"@eslint/js": "9.39.5",
 		"@prisma/client": "^6.19.3",
+		"@prisma/internals": "^7.9.1",
 		"@types/jest": "30.0.0",
 		"@types/node": "^18.15.11",
 		"@types/prettier": "^3.0.0",
@@ -77,8 +82,11 @@
 		"eslint": "^9.39.5",
 		"eslint-config-prettier": "^10.1.8",
 		"fast-check": "4.9.0",
+		"husky": "^9.1.7",
 		"jest": "30.4.2",
+		"lint-staged": "^15.5.2",
 		"prisma": "^6.19.3",
+		"publint": "^0.3.23",
 		"rimraf": "^5.0.10",
 		"ts-jest": "29.4.12",
 		"ts-node": "^10.9.1",
@@ -90,5 +98,11 @@
 	},
 	"resolutions": {
 		"chokidar": "^4.0.3"
+	},
+	"lint-staged": {
+		"src/**/*.ts": [
+			"prettier --write",
+			"eslint --fix"
+		]
 	}
 }

--- a/scripts/verify-packed-tarball.sh
+++ b/scripts/verify-packed-tarball.sh
@@ -27,9 +27,19 @@ WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 echo "--- npm pack ---"
-TARBALL_NAME="$(cd "$ROOT_DIR" && npm pack --silent --pack-destination "$WORK_DIR")"
-TARBALL="$WORK_DIR/$TARBALL_NAME"
-echo "packed: $TARBALL_NAME ($(wc -c <"$TARBALL") bytes)"
+# Deliberately NOT `TARBALL=$(npm pack ...)`: `npm pack` runs the `prepare` lifecycle script,
+# and anything that writes to stdout there lands in the command substitution along with the
+# filename. husky does exactly that when HUSKY=0 is set (it prints "HUSKY=0 skip install"),
+# which every workflow sets -- so capturing stdout works locally and produces a garbage path
+# only in CI. WORK_DIR is a fresh mktemp, so globbing it is unambiguous and immune to whatever
+# `prepare` decides to print.
+(cd "$ROOT_DIR" && npm pack --silent --pack-destination "$WORK_DIR" >/dev/null)
+TARBALL="$(echo "$WORK_DIR"/*.tgz)"
+if [ ! -f "$TARBALL" ]; then
+	echo "FAIL: npm pack produced no tarball in $WORK_DIR"
+	exit 1
+fi
+echo "packed: $(basename "$TARBALL") ($(wc -c <"$TARBALL") bytes)"
 
 PROJECT_DIR="$WORK_DIR/consumer"
 mkdir -p "$PROJECT_DIR"

--- a/scripts/verify-packed-tarball.sh
+++ b/scripts/verify-packed-tarball.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Smoke-tests the *packed tarball* -- what `npm publish` would actually upload -- rather than
+# the repo working tree. verify-prisma-compat.sh runs `dist/index.js` by path straight out of
+# the repo, which means it can't see any of these failure modes:
+#
+#   - a `files` field that omits something dist needs, so the published package is incomplete
+#   - a `bin` entry pointing at a path that isn't in the tarball, so `provider =
+#     "prisma-class-generator"` can't resolve at all
+#   - a runtime import of a package that only exists in devDependencies, which resolves fine
+#     in this repo (everything is installed) and explodes in a user's project
+#
+# That last one is not hypothetical: this package's runtime dependencies were trimmed to
+# @prisma/generator-helper + prettier, and the repo's own node_modules would happily hide a
+# mistake there forever. This test installs the tarball into a throwaway project with nothing
+# else in it and drives it through a real `prisma generate` by provider *name*, so all three
+# are covered.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ ! -f "$ROOT_DIR/dist/index.js" ]; then
+	echo "FAIL: dist/index.js not found — run 'npm run build' first"
+	exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "--- npm pack ---"
+TARBALL_NAME="$(cd "$ROOT_DIR" && npm pack --silent --pack-destination "$WORK_DIR")"
+TARBALL="$WORK_DIR/$TARBALL_NAME"
+echo "packed: $TARBALL_NAME ($(wc -c <"$TARBALL") bytes)"
+
+PROJECT_DIR="$WORK_DIR/consumer"
+mkdir -p "$PROJECT_DIR"
+cd "$PROJECT_DIR"
+
+# A bare project: nothing here but the tarball and the Prisma CLI, so anything the generator
+# needs at runtime has to come from its own declared dependencies.
+npm init -y >/dev/null
+echo "--- npm install <tarball> ---"
+npm install --no-audit --no-fund "$TARBALL" prisma@7 >/dev/null
+
+# The generator is referenced by *name*, exactly as a user would write it -- this is what
+# exercises the `bin` field and the tarball's file list, rather than a path into the repo.
+cat >schema.prisma <<'EOF'
+datasource db {
+  provider = "postgresql"
+}
+
+generator client {
+  provider = "prisma-client"
+  output   = "./generated/client"
+}
+
+generator prismaClassGenerator {
+  provider      = "prisma-class-generator"
+  output        = "./generated/prisma-class"
+  dryRun        = "false"
+  useValidation = "true"
+}
+
+model Foo {
+  id    Int     @id
+  count Int     @default(1)
+  uuid  String  @db.Uuid
+}
+EOF
+
+echo "--- prisma generate (provider resolved by name from node_modules) ---"
+npx prisma generate --schema schema.prisma
+
+OUTPUT_FILE="generated/prisma-class/foo.ts"
+if [ ! -f "$OUTPUT_FILE" ]; then
+	echo "FAIL: $OUTPUT_FILE was not generated from the packed tarball"
+	exit 1
+fi
+
+echo "--- generated output ---"
+cat "$OUTPUT_FILE"
+
+for expected in 'count: number = 1' '@IsUUID()'; do
+	if ! grep -qF "$expected" "$OUTPUT_FILE"; then
+		echo "FAIL: expected to find '$expected' in output generated from the tarball"
+		exit 1
+	fi
+done
+
+# The generator prints its progress through util.ts's log(); a missing runtime dependency
+# would have crashed above, but assert the entry point is where package.json says it is too.
+INSTALLED_MAIN="node_modules/prisma-class-generator/dist/index.js"
+if [ ! -f "$INSTALLED_MAIN" ]; then
+	echo "FAIL: package.json main ($INSTALLED_MAIN) is missing from the installed package"
+	exit 1
+fi
+
+echo "OK: the packed tarball installs and generates correctly in a clean project"

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,11 +1,11 @@
 import { GeneratorOptions } from '@prisma/generator-helper'
-import { parseEnvValue } from '@prisma/internals'
 import * as path from 'path'
 import { PrismaConvertor } from './convertor'
 import {
 	getRelativeTSPath,
 	log,
 	parseBoolean,
+	parseEnvValue,
 	parseNumber,
 	prettierFormat,
 	writeTSFile,

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -12,6 +12,7 @@ import {
 	parseBoolean,
 	parseNumber,
 	prettierFormat,
+	parseEnvValue,
 	toArray,
 	toImportPath,
 	toSnakeCase,
@@ -65,6 +66,46 @@ describe('toSnakeCase', () => {
 		['___', ''],
 	])('%s -> %s', (input, expected) => {
 		expect(toSnakeCase(input)).toBe(expected)
+	})
+})
+
+// Replaces @prisma/internals' parseEnvValue (see util.ts for why it was inlined). These pin
+// the three behaviours that matter, including the `'null'`-as-a-string sentinel that Prisma
+// writes for a value which was never an env var -- reading process.env['null'] instead would
+// break every schema using a plain literal `output`.
+describe('parseEnvValue', () => {
+	const originalEnv = process.env
+
+	afterEach(() => {
+		process.env = originalEnv
+	})
+
+	it('리터럴 값은 그대로 반환한다', () => {
+		expect(parseEnvValue({ fromEnvVar: null, value: '../src/_gen' })).toBe(
+			'../src/_gen',
+		)
+	})
+
+	it("fromEnvVar가 문자열 'null'이면 env가 아니라 리터럴 값을 쓴다", () => {
+		process.env = { ...originalEnv, null: 'WRONG' }
+		expect(parseEnvValue({ fromEnvVar: 'null', value: './out' })).toBe(
+			'./out',
+		)
+	})
+
+	it('fromEnvVar가 있으면 환경변수 값을 읽는다', () => {
+		process.env = { ...originalEnv, PCG_OUTPUT: '/from/env' }
+		expect(
+			parseEnvValue({ fromEnvVar: 'PCG_OUTPUT', value: '/ignored' }),
+		).toBe('/from/env')
+	})
+
+	it('환경변수가 비어 있으면 어떤 변수가 없는지 알려주는 에러를 던진다', () => {
+		process.env = { ...originalEnv }
+		delete process.env.PCG_MISSING
+		expect(() =>
+			parseEnvValue({ fromEnvVar: 'PCG_MISSING', value: null }),
+		).toThrow('PCG_MISSING')
 	})
 })
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,9 +1,8 @@
-import { logger } from '@prisma/internals'
 import * as path from 'path'
 import * as fs from 'fs'
 import { GENERATOR_NAME } from './generator'
 import { GeneratorFormatNotValidError } from './error-handler'
-import { DMMF } from '@prisma/generator-helper'
+import { DMMF, GeneratorOptions } from '@prisma/generator-helper'
 import { Options, format } from 'prettier'
 
 export const capitalizeFirst = (src: string) => {
@@ -81,8 +80,45 @@ export const wrapQuote = (field: DMMF.Field): string => {
 	return `'${field.type}'`
 }
 
+// Reproduces `@prisma/internals`' `logger.info` output exactly, so this package doesn't pull
+// in 28MB of dependency for one console call. Prisma's own logger paints the tag cyan, but
+// only when stdout is a TTY -- a generator is always spawned by the Prisma CLI as a
+// subprocess with its stdio piped, so the tag is never actually colored in practice, and
+// matching the color would mean taking on a color dependency to reproduce bytes nobody sees.
+const PRISMA_INFO_TAG = 'prisma:info'
+
 export const log = (src: string) => {
-	logger.info(`[${GENERATOR_NAME}]:${src}`)
+	console.info(`${PRISMA_INFO_TAG} [${GENERATOR_NAME}]:${src}`)
+}
+
+/** The `{ fromEnvVar, value }` shape Prisma uses for any schema value that may be `env("...")`. */
+type EnvValue = NonNullable<GeneratorOptions['generator']['output']>
+
+/**
+ * Resolves a generator block value that may have been written as `env("VAR")` rather than a
+ * literal — a transcription of `@prisma/internals`' `parseEnvValue`, including its error
+ * message, kept here so that package stays a devDependency (the specs still use its
+ * `getDMMF`) instead of shipping to every user for this one function.
+ *
+ * `fromEnvVar` is compared against the *string* `'null'` on purpose: that's the literal
+ * Prisma writes into the DMMF for a value that wasn't an env var, not a JSON null.
+ */
+export const parseEnvValue = (envValue: EnvValue): string => {
+	if (envValue.fromEnvVar && envValue.fromEnvVar !== 'null') {
+		const fromEnv = process.env[envValue.fromEnvVar]
+		if (!fromEnv) {
+			throw new Error(
+				`Attempted to load provider value using \`env(${envValue.fromEnvVar})\` but it was not present. Please ensure that ${envValue.fromEnvVar} is present in your Environment Variables`,
+			)
+		}
+		return fromEnv
+	}
+	if (envValue.value === null) {
+		throw new Error(
+			`Attempted to read a generator value that Prisma left unset (neither a literal nor an \`env(...)\` reference)`,
+		)
+	}
+	return envValue.value
 }
 
 export const parseBoolean = (value: unknown): boolean => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,7 +32,11 @@
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true,
 		"stripInternal": false,
-		"sourceMap": true,
+		// Off on purpose: `files` publishes only `dist`, so a .js.map's `sources: ["../src/*.ts"]`
+		// points at files that aren't in the tarball, and nothing inlines sourcesContent -- the
+		// maps were ~29% of the published unpacked size while being unusable by anyone. ts-jest
+		// supplies its own sourcemaps for test stack traces regardless of this setting.
+		"sourceMap": false,
 		"forceConsistentCasingInFileNames": true,
 		"allowJs": true,
 		"esModuleInterop": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1167,6 +1167,13 @@
     "@prisma/prisma-schema-wasm" "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad"
     fs-extra "11.3.0"
 
+"@publint/pack@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@publint/pack/-/pack-0.1.6.tgz#0ff2ee9aeafad2d8604f03bfb80e12177c5a0329"
+  integrity sha512-3uVNyGcVplhPZSLVyeIpL7+cIRn1YCSNHLG/rUIlBQMVH8YuN9++YF+5+UDIIO9RW98dujiUoTltO7RDB5bFJA==
+  dependencies:
+    tinyexec "^1.2.4"
+
 "@sinclair/typebox@^0.34.0":
   version "0.34.52"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.34.52.tgz#62f8a686e4ab28a8944902e2ad2d648312ef11cb"
@@ -1593,6 +1600,13 @@ ansi-escapes@^4.3.2:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-escapes@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.3.0.tgz#5395bb74b2150a4a1d6e3c2565f4aeca78d28627"
+  integrity sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==
+  dependencies:
+    environment "^1.0.0"
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -1622,7 +1636,7 @@ ansi-styles@^5.2.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-ansi-styles@^6.1.0:
+ansi-styles@^6.0.0, ansi-styles@^6.1.0, ansi-styles@^6.2.1:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
@@ -1871,6 +1885,11 @@ chalk@^4.0.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^5.4.1:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
+  integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
@@ -1909,6 +1928,21 @@ cjs-module-lexer@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz#b3ca5101843389259ade7d88c77bd06ce55849ca"
   integrity sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==
+
+cli-cursor@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-5.0.0.tgz#24a4831ecf5a6b01ddeb32fb71a4b2088b0dce38"
+  integrity sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==
+  dependencies:
+    restore-cursor "^5.0.0"
+
+cli-truncate@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-4.0.0.tgz#6cc28a2924fee9e25ce91e973db56c7066e6172a"
+  integrity sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==
+  dependencies:
+    slice-ansi "^5.0.0"
+    string-width "^7.0.0"
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -1952,6 +1986,16 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+colorette@^2.0.20:
+  version "2.0.20"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
+  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+
+commander@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-13.1.0.tgz#776167db68c78f38dcce1f9b8d7b8b9a488abf46"
+  integrity sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -2008,7 +2052,7 @@ dataloader@^1.4.0:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-1.4.0.tgz#bca11d867f5d3f1b9ed9f737bd15970c65dff5c8"
   integrity sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==
 
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.4.3:
+debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -2113,6 +2157,11 @@ emittery@^0.13.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
   integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
 
+emoji-regex@^10.3.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.6.0.tgz#bf3d6e8f7f8fd22a65d9703475bc0147357a6b0d"
+  integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -2135,6 +2184,11 @@ enquirer@^2.4.1:
   dependencies:
     ansi-colors "^4.1.1"
     strip-ansi "^6.0.1"
+
+environment@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/environment/-/environment-1.1.0.tgz#8e86c66b180f363c7ab311787e0259665f45a9f1"
+  integrity sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -2264,6 +2318,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eventemitter3@^5.0.1:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.4.tgz#a86d66170433712dde814707ac52b5271ceb1feb"
+  integrity sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==
+
 execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -2278,6 +2337,21 @@ execa@^5.1.1:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
+
+execa@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-8.0.1.tgz#51f6a5943b580f963c3ca9c6321796db8cc39b8c"
+  integrity sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^8.0.1"
+    human-signals "^5.0.0"
+    is-stream "^3.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^5.1.0"
+    onetime "^6.0.0"
+    signal-exit "^4.1.0"
+    strip-final-newline "^3.0.0"
 
 exit-x@^0.2.2:
   version "0.2.2"
@@ -2470,6 +2544,11 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-east-asian-width@^1.0.0, get-east-asian-width@^1.3.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz#216900f91df11a8b2c198c3e1d93d6c035a776b9"
+  integrity sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==
+
 get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
@@ -2479,6 +2558,11 @@ get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+get-stream@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-8.0.1.tgz#def9dfd71742cd7754a7761ed43749a27d02eca2"
+  integrity sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==
 
 giget@^2.0.0:
   version "2.0.0"
@@ -2599,6 +2683,16 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+human-signals@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
+  integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
+
+husky@^9.1.7:
+  version "9.1.7"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
+  integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
+
 iconv-lite@^0.7.0:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.3.tgz#84ee12f963e7de50bc01a13e160a078b3b0f415f"
@@ -2665,6 +2759,18 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
+is-fullwidth-code-point@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz#fae3167c729e7463f8461ce512b080a49268aa88"
+  integrity sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==
+
+is-fullwidth-code-point@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz#046b2a6d4f6b156b2233d3207d4b5a9783999b98"
+  integrity sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==
+  dependencies:
+    get-east-asian-width "^1.3.1"
+
 is-generator-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
@@ -2686,6 +2792,11 @@ is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
+is-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
+  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
 
 is-subdir@^1.1.1:
   version "1.2.0"
@@ -3174,9 +3285,9 @@ jsonfile@^4.0.0:
     graceful-fs "^4.1.6"
 
 jsonfile@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
-  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.2.1.tgz#b6e31717f22cc37330b081ce0051ed5de53af2f6"
+  integrity sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==
   dependencies:
     universalify "^2.0.0"
   optionalDependencies:
@@ -3207,10 +3318,43 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lilconfig@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.3.tgz#a1bcfd6257f9585bf5ae14ceeebb7b559025e4c4"
+  integrity sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
+lint-staged@^15.5.2:
+  version "15.5.2"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-15.5.2.tgz#beff028fd0681f7db26ffbb67050a21ed4d059a3"
+  integrity sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==
+  dependencies:
+    chalk "^5.4.1"
+    commander "^13.1.0"
+    debug "^4.4.0"
+    execa "^8.0.1"
+    lilconfig "^3.1.3"
+    listr2 "^8.2.5"
+    micromatch "^4.0.8"
+    pidtree "^0.6.0"
+    string-argv "^0.3.2"
+    yaml "^2.7.0"
+
+listr2@^8.2.5:
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-8.3.3.tgz#815fc8f738260ff220981bf9e866b3e11e8121bf"
+  integrity sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==
+  dependencies:
+    cli-truncate "^4.0.0"
+    colorette "^2.0.20"
+    eventemitter3 "^5.0.1"
+    log-update "^6.1.0"
+    rfdc "^1.4.1"
+    wrap-ansi "^9.0.0"
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -3240,6 +3384,17 @@ lodash.startcase@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.startcase/-/lodash.startcase-4.4.0.tgz#9436e34ed26093ed7ffae1936144350915d9add8"
   integrity sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==
+
+log-update@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-6.1.0.tgz#1a04ff38166f94647ae1af562f4bd6a15b1b7cd4"
+  integrity sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==
+  dependencies:
+    ansi-escapes "^7.0.0"
+    cli-cursor "^5.0.0"
+    slice-ansi "^7.1.0"
+    strip-ansi "^7.1.0"
+    wrap-ansi "^9.0.0"
 
 lru-cache@^10.2.0:
   version "10.4.3"
@@ -3310,6 +3465,16 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mimic-fn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
+  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
+
+mimic-function@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
+  integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
+
 minimatch@^3.0.4, minimatch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.5.tgz#580c88f8d5445f2bd6aa8f3cadefa0de79fbd69e"
@@ -3341,7 +3506,7 @@ minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
 
-mri@^1.2.0:
+mri@^1.1.0, mri@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
   integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
@@ -3400,6 +3565,13 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+npm-run-path@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.3.0.tgz#e23353d0ebb9317f174e93417e4a4d82d0249e9f"
+  integrity sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==
+  dependencies:
+    path-key "^4.0.0"
+
 nypm@^0.6.0:
   version "0.6.9"
   resolved "https://registry.yarnpkg.com/nypm/-/nypm-0.6.9.tgz#d7c2a2dffd94e1ca0349c721d73d6b776e22899c"
@@ -3427,6 +3599,20 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+onetime@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
+  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
+  dependencies:
+    mimic-fn "^4.0.0"
+
+onetime@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-7.0.0.tgz#9f16c92d8c9ef5120e3acd9dd9957cceecc1ab60"
+  integrity sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==
+  dependencies:
+    mimic-function "^5.0.0"
 
 optionator@^0.9.3:
   version "0.9.4"
@@ -3502,6 +3688,11 @@ package-manager-detector@^0.2.0:
   dependencies:
     quansync "^0.2.7"
 
+package-manager-detector@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/package-manager-detector/-/package-manager-detector-1.8.0.tgz#70c9a2c4bd1a513dcd6cad006a9fcebec22a1253"
+  integrity sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -3533,6 +3724,11 @@ path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-key@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
+  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
 
 path-scurry@^1.11.1:
   version "1.11.1"
@@ -3581,6 +3777,11 @@ picomatch@^4.0.3, picomatch@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
   integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
+
+pidtree@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.1.tgz#3d03fae6183cc07091947dcc1087ce567cd3bcd3"
+  integrity sha512-e0F9AOF1JMrCfBsyJOwU9lNvQ0WtXTq0j/4jk0BQ5JSI9VAybPXmDpPRw/2FQ3e5d3ZFN1mLh7jW99m/jjaptw==
 
 pify@^4.0.1:
   version "4.0.1"
@@ -3653,6 +3854,16 @@ prompts@2.4.2:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+publint@^0.3.23:
+  version "0.3.23"
+  resolved "https://registry.yarnpkg.com/publint/-/publint-0.3.23.tgz#8f67ab89045042a34b732ab522337c1bad9082a9"
+  integrity sha512-5MQipUPcB7MWw84zLUkHrg/H/UBtk3LL+A0GngTTBSsiNJLQurMUaSIRG3edlOrRz4UFe0AOKK9TZdIWviV+jQ==
+  dependencies:
+    "@publint/pack" "^0.1.6"
+    package-manager-detector "^1.7.0"
+    picocolors "^1.1.1"
+    sade "^1.8.1"
 
 punycode@^2.1.0:
   version "2.3.1"
@@ -3747,10 +3958,23 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
+restore-cursor@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-5.1.0.tgz#0766d95699efacb14150993f55baf0953ea1ebe7"
+  integrity sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==
+  dependencies:
+    onetime "^7.0.0"
+    signal-exit "^4.1.0"
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rfdc@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
+  integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
 rimraf@^5.0.10:
   version "5.0.10"
@@ -3765,6 +3989,13 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+sade@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
+  integrity sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==
+  dependencies:
+    mri "^1.1.0"
 
 "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
@@ -3805,7 +4036,7 @@ signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-signal-exit@^4.0.1:
+signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
@@ -3819,6 +4050,22 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slice-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-5.0.0.tgz#b73063c57aa96f9cd881654b15294d95d285c42a"
+  integrity sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==
+  dependencies:
+    ansi-styles "^6.0.0"
+    is-fullwidth-code-point "^4.0.0"
+
+slice-ansi@^7.1.0:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-7.1.2.tgz#adf7be70aa6d72162d907cd0e6d5c11f507b5403"
+  integrity sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==
+  dependencies:
+    ansi-styles "^6.2.1"
+    is-fullwidth-code-point "^5.0.0"
 
 source-map-support@0.5.13:
   version "0.5.13"
@@ -3852,6 +4099,11 @@ stack-utils@^2.0.6:
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+string-argv@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
+  integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
 string-length@^4.0.2:
   version "4.0.2"
@@ -3888,6 +4140,15 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
+string-width@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
+  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
+  dependencies:
+    emoji-regex "^10.3.0"
+    get-east-asian-width "^1.0.0"
+    strip-ansi "^7.1.0"
+
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -3902,7 +4163,7 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^7.0.1:
+strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
   integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
@@ -3923,6 +4184,11 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-final-newline@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
+  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
 strip-json-comments@^3.1.1:
   version "3.1.1"
@@ -4098,9 +4364,9 @@ universalify@^0.1.0:
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 universalify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
-  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
+  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
 unrs-resolver@^1.7.11:
   version "1.12.2"
@@ -4225,6 +4491,15 @@ wrap-ansi@^8.1.0:
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
 
+wrap-ansi@^9.0.0:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz#956832dea9494306e6d209eb871643bb873d7c98"
+  integrity sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==
+  dependencies:
+    ansi-styles "^6.2.1"
+    string-width "^7.0.0"
+    strip-ansi "^7.1.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -4252,6 +4527,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^2.7.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
+  integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
 
 yargs-parser@^21.1.1:
   version "21.1.1"


### PR DESCRIPTION
Two commits: one cuts what this package costs to install, one adds the checks that make that safe to keep doing.

---

## 1. `refactor:` drop `@prisma/internals` from runtime deps, stop publishing sourcemaps

### The dependency

`@prisma/internals` installs **28MB** (25MB of it its own nested `node_modules`) and this package used **two things** from it: `parseEnvValue` and `logger.info`.

It also **never dedupes**. `prisma@7.9.1`'s own dependencies are `mysql2`, `postgres`, `@prisma/dev`, `@prisma/config`, `@prisma/engines`, `@prisma/studio-core` — no `@prisma/internals` among them — so those 28MB were purely additive in every user's install. `@prisma/generator-helper` doesn't re-export either function either (it exports only `GeneratorError`, `GeneratorProcess`, `generatorHandler`).

Both now live in `util.ts`:

- **`parseEnvValue`** — transcribed including its error message, and still compares `fromEnvVar` against the *string* `'null'`. That's the literal Prisma writes for a value that was never an env var; reading `process.env['null']` instead would break every schema using a plain literal `output`. Pinned in `util.spec.ts`.
- **`log()`** — emits `prisma:info <message>` via `console.info`, byte-identical to what `logger.info` produced here. Prisma's logger paints the tag cyan, but only on a TTY, and a generator is always spawned as a subprocess with piped stdio — matching the color would mean taking a color dependency to reproduce bytes nobody sees. Confirmed against a real `prisma generate` run:

  ```
  prisma:info [Prisma Class Generator]:Generate .../generated/prisma-class/foo.ts
  ```

`@prisma/internals` stays a **devDependency** — the specs still use its `getDMMF`, so test coverage is unchanged.

### The sourcemaps

`files` publishes only `dist`, so every `.js.map`'s `sources: ["../src/*.ts"]` pointed at files that aren't in the tarball, and nothing inlined `sourcesContent`. They were **37.9kB of a 130.8kB unpacked package that nobody could use**. ts-jest supplies its own sourcemaps for test stack traces regardless.

### Result

| | before | after |
|---|---|---|
| runtime dependencies | 3 | **2** (`@prisma/generator-helper`, `prettier`) |
| extra install weight | +28MB | — |
| tarball unpacked | 130.8kB | **93.0kB** (-29%) |
| files | 51 | 35 |

---

## 2. `ci:` validate the packed tarball, enforce formatting, add a pre-commit hook

### Gap 1 — nothing validated what npm actually receives

`verify-prisma-compat.sh` runs `dist/index.js` by path out of the repo, so it cannot see a `files` field that omits something, a `bin` pointing at a path not in the tarball, or **a runtime import of a package that's only a devDependency** — all of which resolve fine here because this repo has everything installed. Given commit 1 just trimmed runtime deps, that last one is exactly the risk worth guarding.

`scripts/verify-packed-tarball.sh` packs the package, installs the **tarball** into an empty project containing nothing but the Prisma CLI, and drives a real `prisma generate` through it **by provider name** — exercising `bin` and the file list the way a user would. `publint` runs alongside, checking entry points against the packed file list. New `packaging` CI job.

> `publint --pack npm` is deliberate. On auto it uses `yarn pack` and mis-parses Yarn Classic's tarballs (they include bare directory entries), reporting `main`/`bin`/`files` as missing when all three are present. Its two *real* findings are fixed here: `"type": "commonjs"` is now explicit rather than detected by Node, and `repository.url` moves off the deprecated `git://` protocol.

### Gap 2 — CI never checked formatting

`eslint-config-prettier` *disables* formatting rules rather than checking them, so `npm run lint` passes on an unformatted file. Confirmed on this very branch: a new spec was unformatted and everything was green. `npm run format:check` now runs alongside lint.

### Gap 3 — husky + lint-staged

Local pre-commit prettier/eslint on staged TypeScript only, kept cheap enough that nobody reaches for `--no-verify`. **Both workflows set `HUSKY: 0`**, so `prepare` is a no-op in CI and during publish — git hooks can't run there anyway, and CI stays the source of truth for everything the hook does.

`lint-staged` is pinned to 15.x: 16.x needs Node >=20.17 and 17.x needs >=22.22.1, against this repo's `>=18` floor. Both it and husky get dependabot major guards. (`@arethetypeswrong/cli` was considered and skipped — it requires Node >=20, so it can't run on the Node 18 leg.)

---

## Verification

`typecheck`, `lint`, `format:check`, `test` (213 tests, 6 snapshots), `build`, `lint:package` (publint: *All good!*), and `verify:packed` all pass locally. The tarball smoke test is the direct evidence that the dependency removal is safe — it generated correctly in a project with nothing installed but the Prisma CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)