### PR TITLE
fix: useNonNullableAssertions emits TypeScript that doesn't compile

### DIFF
--- a/.changeset/olive-crabs-argue.md
+++ b/.changeset/olive-crabs-argue.md
@@ -1,0 +1,10 @@
+---
+'prisma-class-generator': patch
+---
+
+Fix `useNonNullableAssertions` producing TypeScript that doesn't compile. A field with a literal
+`@default(...)` was emitted as `views!: number = 0`, which is TS1263 — "Declarations with
+initializers cannot also have definite assignment assertions". Any model with at least one
+defaulted field made the whole generated file fail to build, and `useUndefinedDefault` hit the
+same thing. The assertion is now omitted whenever the field has an initializer, which is what
+definite assignment already means.

--- a/src/components/field.component.spec.ts
+++ b/src/components/field.component.spec.ts
@@ -31,6 +31,32 @@ describe('FieldComponent#echo', () => {
 		expect(field.echo()).toContain('value!: string')
 	})
 
+	// regression test: `value!: number = 1` is TS1263 ("Declarations with initializers cannot
+	// also have definite assignment assertions") — it doesn't compile, so useNonNullableAssertions
+	// used to produce a broken file for any model with a literal @default(...). The initializer
+	// already proves definite assignment, which is all the `!` was asserting.
+	it('기본값이 있으면 nonNullableAssertion이 켜져 있어도 !를 붙이지 않는다', () => {
+		const field = makeField({
+			type: 'number',
+			nonNullableAssertion: true,
+			default: '1',
+		})
+		const echoed = field.echo()
+		expect(echoed).toContain('value: number = 1')
+		expect(echoed).not.toContain('!')
+	})
+
+	it('useUndefinedDefault로 대입식이 생겨도 !를 붙이지 않는다', () => {
+		const field = makeField({
+			type: 'string',
+			nonNullableAssertion: true,
+			useUndefinedDefault: true,
+		})
+		const echoed = field.echo()
+		expect(echoed).toContain('value: string = undefined')
+		expect(echoed).not.toContain('!')
+	})
+
 	// regression test for #34/#56/#76: echo()가 더 이상 Date.parse 휴리스틱으로
 	// 기본값을 추측하지 않고, convertor가 넘겨준 문자열을 그대로 출력해야 한다.
 	it('숫자 문자열 기본값을 Date로 추측해서 감싸지 않는다', () => {

--- a/src/components/field.component.ts
+++ b/src/components/field.component.ts
@@ -16,15 +16,6 @@ export class FieldComponent extends BaseComponent implements Echoable {
 	echo = () => {
 		let name = this.name
 		let type = this.type
-		if (this.nullable === true) {
-			if (this.preserveDefaultNullable) {
-				type = this.type + ' | null'
-			} else {
-				name += '?'
-			}
-		} else if (this.nonNullableAssertion === true) {
-			name += '!'
-		}
 
 		let defaultValue = ''
 		if (this.default) {
@@ -33,6 +24,20 @@ export class FieldComponent extends BaseComponent implements Echoable {
 			if (this.useUndefinedDefault === true) {
 				defaultValue = `= undefined`
 			}
+		}
+
+		if (this.nullable === true) {
+			if (this.preserveDefaultNullable) {
+				type = this.type + ' | null'
+			} else {
+				name += '?'
+			}
+		} else if (this.nonNullableAssertion === true && defaultValue === '') {
+			// `views!: number = 0` is TS1263 ("Declarations with initializers cannot also have
+			// definite assignment assertions") -- it doesn't compile at all. The assertion is
+			// also redundant there: an initializer is precisely what "definitely assigned"
+			// means, which is the only thing the `!` was claiming.
+			name += '!'
 		}
 
 		return FIELD_TEMPLATE.replace('#!{NAME}', name)


### PR DESCRIPTION
## The bug

`useNonNullableAssertions = "true"` combined with a literal `@default(...)` emits:

```ts
views!: number = 0
```

which is **TS1263 — "Declarations with initializers cannot also have definite assignment assertions"**:

```
$ tsc --noEmit --strict a.ts
a.ts(2,7): error TS1263: Declarations with initializers cannot also have definite assignment assertions.
```

This isn't a style nit — the file **does not compile**, so a single defaulted field breaks the entire generated output for anyone using that option. `useUndefinedDefault` hits the same path, emitting `value!: string = undefined`.

## The fix

Skip the assertion whenever an initializer is emitted. Nothing is lost: an initializer *is* definite assignment, which is the only thing the `!` was asserting.

```diff
-} else if (this.nonNullableAssertion === true) {
+} else if (this.nonNullableAssertion === true && defaultValue === '') {
```

(The default-value computation moved above the name/type block so the check has something to read.)

## How it surfaced

Found while compiling generated output against a real `@nestjs/swagger` project with `tsc --strict` — the first time this option combination had been through an actual TypeScript compiler rather than only `toContain()` string assertions. The existing spec asserted `value!: string` for the no-default case, which was correct and still passes; nothing covered "assertion **plus** initializer".

Two regression tests added for exactly that pair. The golden fixture snapshots are unchanged — they run with `useNonNullableAssertions: false`, which is precisely why this survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)