### PR TITLE
feat: generate Create/Update DTO classes as mapped-type compositions (makeDtoFiles)

### DIFF
--- a/.changeset/light-donuts-shave.md
+++ b/.changeset/light-donuts-shave.md
@@ -1,0 +1,15 @@
+---
+'prisma-class-generator': minor
+---
+
+Add `makeDtoFiles`, which generates `Create<Model>` and `Update<Model>` classes alongside each
+model class. They're compositions rather than copies — `CreateUser extends OmitType(User, [...] as
+const)` and `UpdateUser extends PartialType(CreateUser)` — so a field's type, Swagger metadata and
+validators stay declared in exactly one place, and NestJS's mapped types carry all three through.
+Imported from `@nestjs/swagger` when `useSwagger` is on, `@nestjs/mapped-types` otherwise.
+
+A field leaves the `Create` DTO only when the schema itself says a client can't supply it: a
+function-based `@default(...)` (`autoincrement()`, `uuid()`, `now()`, `dbgenerated(...)`, …),
+`@updatedAt`, or a relation field. Literal defaults like `@default(0)`, relation foreign-key
+scalars, and an `@id` without a default all stay — nothing is inferred from field names. Off by
+default, so existing output is unchanged.

--- a/README.md
+++ b/README.md
@@ -370,6 +370,14 @@ export class ProductDto extends IntersectionType(
     -   makes index file, default value is **true**
 -   _separateRelationFields_
     -   puts relational fields into different file for each model. This way the class will match the object returned by a Prisma query, default value is **false**
+-   _makeDtoFiles_
+    -   also generates `Create<Model>` and `Update<Model>` classes for each model, default value is **false**
+        -   they're **compositions**, not copies: `CreateUser extends OmitType(User, [...] as const)` and `UpdateUser extends PartialType(CreateUser)`, so each field's type, Swagger metadata and validators stay declared in exactly one place (NestJS's mapped types carry all three through)
+        -   imported from `@nestjs/swagger` when `useSwagger` is on, otherwise from `@nestjs/mapped-types`
+        -   a field is omitted from `Create` only when the schema itself says the client can't supply it: a **function-based** `@default(...)` (`autoincrement()`, `uuid()`, `cuid()`, `now()`, `auto()`, `dbgenerated(...)`), `@updatedAt`, or a relation field. A *literal* default like `@default(0)` is kept — "there's a fallback" isn't "you may not set it" — and so is a relation's foreign-key scalar (`authorId`), which is the value a REST client actually posts
+        -   an `@id` **without** a default (e.g. `id String @id`) is kept too: the caller has to provide it
+        -   composite types (MongoDB `type` blocks) get no DTOs — they're embedded values, not entities with their own endpoints
+        -   with `separateRelationFields`, the DTOs compose the base class (never the `*Relations` one)
 -   _clientImportPath_
     -   set prisma client import path manually, default value is **@prisma/client**
         -   set this explicitly when using Prisma 7's `prisma-client` generator, since its output is no longer `@prisma/client` by default
@@ -491,10 +499,11 @@ flowchart LR
     `ClassSerializerInterceptor`
 -   `preserveDecimal` option to keep `Decimal` fields precision-safe as `Prisma.Decimal`
 -   Doc comments and literal `@default(...)` values become Swagger `description`/`example`
+-   Optional `Create`/`Update` DTO classes (`makeDtoFiles`), generated as NestJS mapped-type
+    compositions so field definitions are never duplicated
 
 ### Future Plan
 
--   Support DTO (Create/Update/Connect style classes generated per model)
 -   Support custom path, case or name per each model
 
 ---
@@ -510,16 +519,17 @@ shape.
 | Swagger decorators | ✅ | ✅ | ✅ |
 | class-validator decorators | ✅ | ✅ | ✅ |
 | GraphQL (TypeGraphQL) decorators | ✅ | — | — |
-| Classes generated per model | 1 (or 2 with `separateRelationFields`) | 1 (or 2 with `separateRelationFields`) | 5 (`Entity`, `Dto`, `CreateDto`, `UpdateDto`, `ConnectDto`) |
+| Classes generated per model | 1, or 3 with `makeDtoFiles` (`Model`, `CreateModel`, `UpdateModel`), or 2 with `separateRelationFields` | 1 (or 2 with `separateRelationFields`) | 5 (`Entity`, `Dto`, `CreateDto`, `UpdateDto`, `ConnectDto`) |
+| Create/Update DTO strategy | mapped-type composition — `OmitType`/`PartialType` over the model class, so a field is declared once | — | fully expanded classes, each field re-declared per DTO |
 | Databases verified against | postgresql, mysql, mongodb, sqlserver, sqlite, cockroachdb ([golden-tested](./prisma)) | not specified in their docs | not specified in their docs |
 | Prisma versions | 5, 6, 7 (both `prisma-client-js` and `prisma-client`) | `>=6.19 <8` (peer dependency) | not version-pinned |
 | Per-field customization | `/// @skip`, `/// @ApiHideProperty`, `/// @exclude` doc-comment directives | schema-comment annotations (e.g. `@description`) | schema-comment annotations (e.g. `@description`, `@minimum`) |
 | Native-type-aware validators | `@db.Uuid`/`@db.ObjectId`/`@db.Inet`/`@db.VarChar(n)`/unsigned ints → sharper class-validator decorators (Prisma 6+) | not specified in their docs | not specified in their docs |
 
-If you want a single class per model that mirrors what Prisma Client actually returns, and you
-compose your own Create/Update DTOs from it (see the FAQ below), this library is a good fit. If
-you'd rather have a full Create/Update/Connect DTO set generated for you out of the box,
-`prisma-generator-nestjs-dto` does more of that decision-making for you.
+If you want a class per model that mirrors what Prisma Client actually returns — optionally with
+`Create`/`Update` DTOs composed from it rather than duplicated out of it — this library is a good
+fit. If you'd rather have a full Create/Update/**Connect** DTO set with each field expanded per
+class, `prisma-generator-nestjs-dto` makes more of those decisions for you.
 
 ---
 
@@ -541,9 +551,25 @@ use the generated classes just as directly.
 
 **3. OK, so how do I actually build Create/Update DTOs from the generated class?**
 
-The generated class is decorated with `@nestjs/swagger`'s `@ApiProperty`, which is exactly
-what `@nestjs/swagger`'s `PartialType`/`OmitType`/`PickType` helpers are designed to compose —
-no extra code generation needed, it already works out of the box:
+Set `makeDtoFiles = "true"` and they're generated for you (see the option above) — as
+compositions of the model class, so no field is ever declared twice:
+
+```typescript
+// create_user.ts
+export class CreateUser extends OmitType(User, ['id', 'createdAt', 'updatedAt'] as const) {}
+
+// update_user.ts
+export class UpdateUser extends PartialType(CreateUser) {}
+```
+
+The omit list comes only from things the schema states outright — a function-based
+`@default(...)`, `@updatedAt`, or a relation field — never from guessing at field names.
+
+If your API's create payload differs from that (an admin route that *does* set `id`, a
+`ConnectDto`-style nested write, a field you want dropped for reasons the schema doesn't
+express), write it by hand — the generated class is decorated with `@nestjs/swagger`'s
+`@ApiProperty`, which is exactly what `PartialType`/`OmitType`/`PickType` are designed to
+compose, so this has always worked without any generator support:
 
 ```typescript
 import { OmitType, PartialType } from '@nestjs/swagger'
@@ -556,13 +582,8 @@ export class CreateUserDto extends OmitType(User, ['id', 'createdAt', 'updatedAt
 export class UpdateUserDto extends PartialType(CreateUserDto) {}
 ```
 
-If you'd rather not repeat the field list per model, pair this with `/// @skip` (see
-[Per-field directives](#per-field-directives)) on a *separate* generator run with a different
-`output` path to produce an already-trimmed base class — but for most projects, `OmitType` on
-the regular generated class is the simpler starting point. If you want this scaffolding
-generated automatically instead, `prisma-generator-nestjs-dto` does that out of the box (see
-the comparison table above) — this library deliberately stops one step short so the choice of
-which fields to omit stays explicit in your code, not implicit in generator config.
+A hand-written DTO and `makeDtoFiles` coexist fine — the generated `CreateUser`/`UpdateUser`
+are ordinary classes you can ignore, extend, or `OmitType` further.
 
 **4. I'm getting a decorators error (e.g. Babel's `Missing plugin "decorators"`) when I import a generated class — what's missing?**
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ See [CHANGELOG.md](./CHANGELOG.md) for release notes. Found a bug or want a feat
 question instead? Ask in [Discussions](https://github.com/kimjbstar/prisma-class-generator/discussions) —
 it's faster for you and keeps the issue tracker focused on actual bugs.
 
+**Contents** · [Usage](#usage) · [Supported options](#supported-options) ·
+[Per-field directives](#per-field-directives) · [Databases](#supported-databases) ·
+[Prisma versions](#supported-prisma-versions) · [Features](#feature) ·
+[Comparison with similar tools](#comparison-with-similar-tools) · [FAQ](#faq)
+
+> **In a hurry?** `dryRun` defaults to **`true`**, so the first run prints the classes to your
+> terminal instead of writing them. Set `dryRun = "false"` in the generator block once the
+> preview looks right — see [Supported options](#supported-options).
+
 ## Prisma
 
 > [Prisma](https://www.prisma.io/) is a database ORM library for Node.js and TypeScript.
@@ -76,11 +85,15 @@ export class ProductDto extends IntersectionType(
 
 ### Usage
 
-1. **Install**
+1. **Install** — as a dev dependency: it runs as part of `prisma generate` and the classes it
+   writes don't import it, so it never needs to ship to production.
 
     ```shell
-    npm install prisma-class-generator
-    yarn add prisma-class-generator
+    npm install --save-dev prisma-class-generator
+    ```
+
+    ```shell
+    yarn add --dev prisma-class-generator
     ```
 
 2. **Define the generator in `schema.prisma`**
@@ -326,6 +339,29 @@ export class ProductDto extends IntersectionType(
 
 #### Supported options
 
+Every value is written as a **string** in `schema.prisma` (`dryRun = "false"`, not `dryRun = false`) —
+that's how Prisma passes generator config through.
+
+| option | default | what it does |
+|---|---|---|
+| `output` | `../src/_gen/prisma-class` | where the files are written |
+| `dryRun` | **`true`** | print to the terminal instead of writing. **Set to `"false"` to actually generate files** |
+| `makeIndexFile` | `true` | also emit `index.ts` with the `PrismaModel` namespace and `extraModels` |
+| `makeDtoFiles` | `false` | also emit `Create<Model>`/`Update<Model>`, composed with NestJS mapped types |
+| `separateRelationFields` | `false` | move relation fields into a separate `<Model>Relations` class |
+| `useSwagger` | **`true`** | `@ApiProperty`/`@ApiPropertyOptional`, plus `description`/`example` from the schema |
+| `useGraphQL` | `false` | TypeGraphQL's `@Field` and `@ObjectType` |
+| `useValidation` | `false` | class-validator decorators, sharpened by `@db.*` native types on Prisma 6+ |
+| `validateNestedRelations` | `false` | adds `@ValidateNested()` to relation/composite fields (needs `useValidation`) |
+| `useSerialization` | `false` | class-transformer `@Exclude()`/`@Expose()`/`@Type()` |
+| `useNonNullableAssertions` | `false` | `!` on non-optional fields, for TypeScript strict mode |
+| `preserveDefaultNullable` | `false` | type nullable fields as `\| null` instead of making them optional |
+| `useUndefinedDefault` | `false` | `= undefined` for fields with no default |
+| `preserveDecimal` | `false` | `Prisma.Decimal` instead of `number` for `Decimal` fields |
+| `clientImportPath` | `@prisma/client` | where generated enums and the `Prisma` namespace are imported from |
+
+Details for each:
+
 -   _dryRun_
     -   Controls whether files are written to disk or just printed to the terminal. default value is **true**
         -   once the printed preview looks right, set this option to **false** to actually write the files
@@ -340,7 +376,7 @@ export class ProductDto extends IntersectionType(
     -   generates TypeGraphQL decorator (`@Field` from `@nestjs/graphql`). default value is **false**
 -   _useValidation_
     -   generates [class-validator](https://github.com/typestack/class-validator) decorators (`@IsInt`, `@IsString`, `@IsOptional`, `@IsEnum`, `@IsArray`, ...) based on each field's Prisma type, for use with NestJS's `ValidationPipe`. default value is **false**
-        -   relation and composite-type fields are intentionally left without a validator — this library hands DTO composition to the caller (see the FAQ below), so it doesn't guess what a nested payload should look like
+        -   relation and composite-type fields are intentionally left without a type-specific validator: validating one means assuming a shape for the nested payload, which the schema doesn't state. Turn on `validateNestedRelations` if the relation field *is* the payload you want validated as-is
         -   `DateTime` fields use `@IsDateString()` rather than `@IsDate()`, so it validates the raw string a JSON request body actually contains without requiring `class-transformer`'s `@Type(() => Date)` to run first
         -   `BigInt`/`Bytes`/`Json` fields get no type-specific validator — class-validator has no direct equivalent for those
         -   a field's `@db.*` native type sharpens the validator further when it describes a real

--- a/src/components/class.component.ts
+++ b/src/components/class.component.ts
@@ -1,6 +1,7 @@
 import { Echoable } from '../interfaces/echoable'
 import { FieldComponent } from './field.component'
 import { CLASS_TEMPLATE } from '../templates/class.template'
+import { DTO_CLASS_TEMPLATE } from '../templates/dto.template'
 import { BaseComponent } from './base.component'
 
 export class ClassComponent extends BaseComponent implements Echoable {
@@ -14,12 +15,31 @@ export class ClassComponent extends BaseComponent implements Echoable {
 	extra = ''
 	types?: string[]
 
+	// Set only on the DTO classes (see PrismaConvertor#getDtoClasses): the whole class body is
+	// `extends <this expression>`, so none of the field/decorator state above applies.
+	extendsExpression?: string
+	// Names of *other generated* classes this class references. They're imported the same way
+	// relation types are (through FileComponent.TEMP_PREFIX, resolved to a relative path once
+	// every file's path is known), because a DTO doesn't know where its base class landed at
+	// construction time either.
+	generatedClassImports: string[] = []
+	// Third-party imports the class itself needs, as opposed to ones implied by its decorators
+	// -- currently just the mapped-type helpers a DTO composes with.
+	externalImports: { item: string; from: string }[] = []
+
 	constructor(obj: { name: string }) {
 		super(obj)
 		this.name = obj.name
 	}
 
 	echo = () => {
+		if (this.extendsExpression) {
+			return DTO_CLASS_TEMPLATE.replace('#!{NAME}', this.name).replace(
+				'#!{EXTENDS}',
+				this.extendsExpression,
+			)
+		}
+
 		const fieldContent = this.fields.map((_field) => _field.echo())
 		const str = CLASS_TEMPLATE.replace(
 			'#!{DECORATORS}',

--- a/src/components/file.component.spec.ts
+++ b/src/components/file.component.spec.ts
@@ -271,3 +271,69 @@ describe('useValidation — class-validator import', () => {
 		)
 	})
 })
+
+describe('makeDtoFiles — DTO 파일의 import 경로 해석', () => {
+	const DTO_SCHEMA = `
+      model Post {
+        id       Int    @id @default(autoincrement())
+        title    String
+        authorId String
+        author   Author @relation(fields: [authorId], references: [id])
+      }
+
+      model Author {
+        id    String @id
+        posts Post[]
+      }
+    `
+
+	// DTO는 자기 base 클래스를 값으로(extends 절에서) 참조하므로, relation 필드와 달리
+	// type-only alias로는 대체할 수 없다. 그래서 값 import 하나만 등록돼야 한다.
+	it('Create DTO는 base 클래스를 실제 생성 파일명 경로로 값 import한다', async () => {
+		const files = await buildFiles(DTO_SCHEMA, { makeDtoFiles: true })
+
+		const createPost = findFile(files, 'CreatePost')
+		expect(createPost.filename).toBe('create_post.ts')
+
+		const baseImport = findImport(createPost, './post')
+		expect(baseImport.items).toEqual(['Post'])
+		// 이 스펙의 buildFiles는 useSwagger: false가 기본이라 mapped type이
+		// @nestjs/mapped-types에서 온다 (출처 분기 자체는 convertor.spec.ts가 검증).
+		expect(findImportFrom(createPost, 'OmitType')).toBe(
+			'@nestjs/mapped-types',
+		)
+	})
+
+	it('Update DTO는 모델이 아니라 Create DTO를 import한다', async () => {
+		const files = await buildFiles(DTO_SCHEMA, { makeDtoFiles: true })
+
+		const updatePost = findFile(files, 'UpdatePost')
+		expect(updatePost.filename).toBe('update_post.ts')
+		expect(findImport(updatePost, './create_post').items).toEqual([
+			'CreatePost',
+		])
+		expect(findImportFrom(updatePost, 'PartialType')).toBe(
+			'@nestjs/mapped-types',
+		)
+	})
+
+	// DTO에는 필드가 하나도 없으니 GraphQL 헬퍼(ID/Int/registerEnumType/GraphQLJSONObject)를
+	// 참조할 곳도 없다 -- 넣으면 100% 미사용 import가 된다.
+	it('useGraphQL이 켜져 있어도 DTO 파일에는 GraphQL import를 넣지 않는다', async () => {
+		const files = await buildFiles(DTO_SCHEMA, {
+			makeDtoFiles: true,
+			useGraphQL: true,
+		})
+
+		const createPost = findFile(files, 'CreatePost')
+		expect(
+			createPost.imports.some((i) => i.from === '@nestjs/graphql'),
+		).toBe(false)
+		// 반면 모델 클래스에는 그대로 들어간다
+		expect(
+			findFile(files, 'Post').imports.some(
+				(i) => i.from === '@nestjs/graphql',
+			),
+		).toBe(true)
+	})
+})

--- a/src/components/file.component.ts
+++ b/src/components/file.component.ts
@@ -99,12 +99,36 @@ export class FileComponent implements Echoable {
 	}
 
 	resolveImports() {
+		this.registerGeneratedClassImports()
+		this.registerExternalImports()
 		this.registerRelationImports()
 		this.registerEnumImports()
 		this.registerPrismaNamespaceImport()
 		this.registerDecoratorImports()
 		this.registerCompositeTypeImports()
 		this.registerGraphQLImports()
+	}
+
+	/** A DTO composes other generated classes and declares no fields of its own. */
+	private get isMappedTypeDto() {
+		return !!this.prismaClass.extendsExpression
+	}
+
+	private registerGeneratedClassImports() {
+		this.prismaClass.generatedClassImports.forEach((className) => {
+			// value import only, unlike relation fields: the name is used inside an `extends`
+			// clause, which is a real runtime reference, so a type-only import can't serve it.
+			this.registerImport(
+				className,
+				FileComponent.TEMP_PREFIX + className,
+			)
+		})
+	}
+
+	private registerExternalImports() {
+		this.prismaClass.externalImports.forEach(({ item, from }) => {
+			this.registerImport(item, from)
+		})
 	}
 
 	private registerRelationImports() {
@@ -172,6 +196,11 @@ export class FileComponent implements Echoable {
 	}
 
 	private registerGraphQLImports() {
+		// These are emitted for any class that *might* reference them from a field decorator.
+		// A DTO has no fields at all, so for those they'd be guaranteed-unused imports.
+		if (this.isMappedTypeDto) {
+			return
+		}
 		if (this._useGraphQL) {
 			this.registerImport('ID', '@nestjs/graphql')
 			this.registerImport('Int', '@nestjs/graphql')

--- a/src/convertor.spec.ts
+++ b/src/convertor.spec.ts
@@ -1,6 +1,7 @@
 import { getDMMF } from '@prisma/internals'
 import { DMMF } from '@prisma/generator-helper'
 import { PrismaConvertor } from './convertor'
+import { ClassComponent } from './components/class.component'
 import { PrismaClassGeneratorConfig } from './generator'
 
 type SupportedProvider = 'postgresql' | 'mysql' | 'mongodb'
@@ -1174,5 +1175,165 @@ describe('PrismaConvertor#extractSwaggerDecoratorFromField (description / exampl
     `)
 		const echoed = convert(model, { useSwagger: true }).echo()
 		expect(echoed).not.toContain('example:')
+	})
+})
+
+// The DTO classes are compositions rather than expanded copies, so what's worth pinning is the
+// *omit list*: which fields the schema says a client can't supply on create. Everything here is
+// derived from a schema fact (a function-based @default, @updatedAt, being a relation), never
+// from a field's name -- the same rule the rest of this generator follows.
+describe('PrismaConvertor#getClasses (makeDtoFiles)', () => {
+	const DTO_SCHEMA = `
+      model Post {
+        id        Int      @id @default(autoincrement())
+        title     String
+        views     Int      @default(0)
+        createdAt DateTime @default(now())
+        updatedAt DateTime @updatedAt
+        authorId  String
+        author    Author   @relation(fields: [authorId], references: [id])
+      }
+
+      model Author {
+        id    String @id
+        name  String
+        posts Post[]
+      }
+    `
+
+	const getClasses = async (
+		modelBlock: string,
+		config: Partial<PrismaClassGeneratorConfig> = {},
+		provider: SupportedProvider = 'postgresql',
+	) => {
+		const dmmf = await getDMMF({
+			datamodel: baseSchema(modelBlock, provider),
+		})
+		const convertor = new PrismaConvertor()
+		convertor.dmmf = dmmf
+		convertor.config = {
+			...defaultConfig,
+			useSwagger: true,
+			makeDtoFiles: true,
+			...config,
+		}
+		return convertor.getClasses()
+	}
+
+	const findClass = (classes: ClassComponent[], name: string) => {
+		const found = classes.find((c) => c.name === name)
+		if (!found) {
+			throw new Error(
+				`no generated class named "${name}" (got: ${classes
+					.map((c) => c.name)
+					.join(', ')})`,
+			)
+		}
+		return found
+	}
+
+	it('makeDtoFiles가 꺼져 있으면(기본값) DTO 클래스를 만들지 않는다', async () => {
+		const classes = await getClasses(DTO_SCHEMA, { makeDtoFiles: false })
+		expect(classes.map((c) => c.name)).toEqual(['Post', 'Author'])
+	})
+
+	it('모델마다 Create/Update 클래스를 추가로 만든다', async () => {
+		const classes = await getClasses(DTO_SCHEMA)
+		expect(classes.map((c) => c.name)).toEqual([
+			'Post',
+			'CreatePost',
+			'UpdatePost',
+			'Author',
+			'CreateAuthor',
+			'UpdateAuthor',
+		])
+	})
+
+	// autoincrement()/now()는 DB가, @updatedAt은 Prisma가 채운다. relation은 다른 엔티티라
+	// 이 라이브러리가 한 번도 만든 적 없는 중첩 쓰기 모양을 가정해야 해서 뺀다.
+	it('DB/Prisma가 채우는 필드와 relation 필드를 Create에서 제외한다', async () => {
+		const classes = await getClasses(DTO_SCHEMA)
+		expect(findClass(classes, 'CreatePost').extendsExpression).toBe(
+			"OmitType(Post, ['id', 'createdAt', 'updatedAt', 'author'] as const)",
+		)
+	})
+
+	// relation을 뺀 자리에 남는 FK 스칼라(authorId)가 REST 클라이언트가 실제로 보내는 값이고,
+	// 리터럴 @default(0)은 "안 보내도 된다"이지 "보내면 안 된다"가 아니다.
+	it('FK 스칼라와 리터럴 기본값 필드는 Create에 남긴다', async () => {
+		const classes = await getClasses(DTO_SCHEMA)
+		const omitted = findClass(classes, 'CreatePost').extendsExpression
+		expect(omitted).not.toContain("'authorId'")
+		expect(omitted).not.toContain("'views'")
+		expect(omitted).not.toContain("'title'")
+	})
+
+	// `id String @id`는 기본값이 없으니 호출자가 반드시 줘야 한다 -- @id라는 이유만으로
+	// 빼면 그 모델은 아예 생성이 불가능해진다.
+	it('기본값 없는 @id는 Create에 남긴다', async () => {
+		const classes = await getClasses(DTO_SCHEMA)
+		expect(findClass(classes, 'CreateAuthor').extendsExpression).toBe(
+			"OmitType(Author, ['posts'] as const)",
+		)
+	})
+
+	it('Update는 모델이 아니라 Create의 PartialType이다', async () => {
+		const classes = await getClasses(DTO_SCHEMA)
+		const update = findClass(classes, 'UpdatePost')
+		expect(update.extendsExpression).toBe('PartialType(CreatePost)')
+		expect(update.generatedClassImports).toEqual(['CreatePost'])
+	})
+
+	it('useSwagger가 켜져 있으면 mapped type을 @nestjs/swagger에서 가져온다', async () => {
+		const classes = await getClasses(DTO_SCHEMA)
+		expect(findClass(classes, 'CreatePost').externalImports).toEqual([
+			{ item: 'OmitType', from: '@nestjs/swagger' },
+		])
+	})
+
+	it('useSwagger가 꺼져 있으면 @nestjs/mapped-types에서 가져온다', async () => {
+		const classes = await getClasses(DTO_SCHEMA, { useSwagger: false })
+		expect(findClass(classes, 'CreatePost').externalImports).toEqual([
+			{ item: 'OmitType', from: '@nestjs/mapped-types' },
+		])
+	})
+
+	// separateRelationFields를 켜면 base 클래스에 이미 relation이 없다. omit 키를 모델이 아니라
+	// base 클래스의 필드에서 뽑는 이유가 이것 -- 모델 기준으로 뽑으면 base에 없는 'author'를
+	// 빼려 해서 OmitType이 타입 에러가 난다.
+	it('separateRelationFields면 base 클래스를 확장하고 Relations에는 DTO를 만들지 않는다', async () => {
+		const classes = await getClasses(DTO_SCHEMA, {
+			separateRelationFields: true,
+		})
+		expect(findClass(classes, 'CreatePost').extendsExpression).toBe(
+			"OmitType(Post, ['id', 'createdAt', 'updatedAt'] as const)",
+		)
+		expect(
+			classes.find((c) => c.name === 'CreatePostRelations'),
+		).toBeUndefined()
+	})
+
+	// composite type은 문서에 박히는 값이지 자기 엔드포인트를 갖는 엔티티가 아니다.
+	it('MongoDB composite type에는 DTO를 만들지 않는다', async () => {
+		const classes = await getClasses(
+			`
+        model Dealer {
+          id      String          @id @default(auto()) @map("_id") @db.ObjectId
+          address ShippingAddress
+        }
+
+        type ShippingAddress {
+          city String
+        }
+      `,
+			{},
+			'mongodb',
+		)
+		expect(classes.map((c) => c.name)).toEqual([
+			'Dealer',
+			'CreateDealer',
+			'UpdateDealer',
+			'ShippingAddress',
+		])
 	})
 })

--- a/src/convertor.ts
+++ b/src/convertor.ts
@@ -119,6 +119,35 @@ const formatEnumDefault = (dmmfField: DMMF.Field): string => {
 	return `${dmmfField.type}.${dmmfField.default}`
 }
 
+/**
+ * True for a field a client can't meaningfully supply when *creating* a row, judged purely from
+ * what the schema states rather than from the field's name:
+ *
+ * - a function-based `@default(...)` (`autoincrement()`, `uuid()`, `cuid()`, `now()`,
+ *   `auto()`, `dbgenerated(...)`, `sequence()`) means the database or Prisma produces the value.
+ *   DMMF represents these as an `{ name, args }` object, which is what distinguishes them from a
+ *   literal default like `@default(0)` -- and a literal default is deliberately *kept*, since
+ *   "there's a fallback" isn't the same as "you may not set it".
+ * - `@updatedAt` is maintained by Prisma on every write.
+ * - a relation field holds another entity, not a value; this generator has never invented a
+ *   nested-write shape (see the README FAQ), so the relation's own foreign-key scalar -- which
+ *   is an ordinary field a REST client does post -- is what stays behind.
+ *
+ * Note an `@id` *without* a default stays: `id String @id` genuinely has to come from the caller.
+ */
+const isCreateDtoOmittedField = (dmmfField: DMMF.Field): boolean => {
+	if (dmmfField.relationName) {
+		return true
+	}
+	if (dmmfField.isUpdatedAt) {
+		return true
+	}
+	return (
+		typeof dmmfField.default === 'object' &&
+		!Array.isArray(dmmfField.default)
+	)
+}
+
 export interface SwaggerDecoratorParams {
 	isArray?: boolean
 	type?: string
@@ -547,6 +576,64 @@ export class PrismaConvertor {
 	}
 
 	/**
+	 * Create/Update DTO classes for one model, expressed as NestJS mapped-type compositions of
+	 * the model class rather than as expanded copies of it. That keeps each field's type and
+	 * validators declared in exactly one place, and it's the same composition the README FAQ
+	 * has always told people to write by hand.
+	 *
+	 * The omitted keys are read off `baseClass.fields` rather than off the model, so they're
+	 * guaranteed to be `keyof` the class being composed -- otherwise `separateRelationFields`
+	 * (whose base class has already dropped relations) or a `/// @skip`ped field would produce
+	 * an `OmitType` key that doesn't type-check.
+	 */
+	private getDtoClasses = (
+		model: DMMF.Model,
+		baseClass: ClassComponent,
+	): ClassComponent[] => {
+		// @nestjs/swagger re-exports the mapped types *and* carries OpenAPI metadata through
+		// them; @nestjs/mapped-types is the same API without the Swagger dependency, for
+		// projects not generating Swagger decorators in the first place.
+		const mappedTypesFrom = this.config.useSwagger
+			? '@nestjs/swagger'
+			: '@nestjs/mapped-types'
+
+		const omittedByName = new Map(
+			model.fields.map((field) => [field.name, field]),
+		)
+		const omittedKeys = baseClass.fields
+			.map((field) => field.name)
+			.filter((name) => {
+				const dmmfField = omittedByName.get(name)
+				return !!dmmfField && isCreateDtoOmittedField(dmmfField)
+			})
+
+		const createClass = new ClassComponent({
+			name: `Create${baseClass.name}`,
+		})
+		createClass.extendsExpression = `OmitType(${baseClass.name}, [${omittedKeys
+			.map((key) => `'${key}'`)
+			.join(', ')}] as const)`
+		createClass.generatedClassImports = [baseClass.name]
+		createClass.externalImports = [
+			{ item: 'OmitType', from: mappedTypesFrom },
+		]
+
+		// Update extends Create, not the model: everything Create already excluded (generated
+		// ids, @updatedAt, relations) has no business in an update payload either, and this
+		// way the two can't drift apart.
+		const updateClass = new ClassComponent({
+			name: `Update${baseClass.name}`,
+		})
+		updateClass.extendsExpression = `PartialType(${createClass.name})`
+		updateClass.generatedClassImports = [createClass.name]
+		updateClass.externalImports = [
+			{ item: 'PartialType', from: mappedTypesFrom },
+		]
+
+		return [createClass, updateClass]
+	}
+
+	/**
 	 * one prisma model could generate multiple classes!
 	 *
 	 * CASE 1: if you want separate model to normal class and relation class
@@ -557,19 +644,21 @@ export class PrismaConvertor {
 
 		/** separateRelationFields */
 		if (this.config.separateRelationFields === true) {
-			const modelVariants: Pick<
-				ConvertModelInput,
-				'extractRelationFields' | 'postfix'
-			>[] = [
-				{ extractRelationFields: true, postfix: 'Relations' },
-				{ extractRelationFields: false },
-			]
 			return [
-				...modelVariants.flatMap((variant) =>
-					models.map((model) =>
-						this.getClass({ model, useGraphQL, ...variant }),
-					),
+				...models.map((model) =>
+					this.getClass({
+						model,
+						useGraphQL,
+						extractRelationFields: true,
+						postfix: 'Relations',
+					}),
 				),
+				// DTOs compose the *base* class (the one without relation fields), never the
+				// *Relations one -- a relations-only class has nothing a client would post.
+				...this.getModelClassesWithDtos(models, {
+					useGraphQL,
+					extractRelationFields: false,
+				}),
 				// mongodb Types support
 				...this.dmmf.datamodel.types.map((model) =>
 					this.getClass({
@@ -582,12 +671,26 @@ export class PrismaConvertor {
 		}
 
 		return [
-			...models.map((model) => this.getClass({ model, useGraphQL })),
-			// mongodb Types support
+			...this.getModelClassesWithDtos(models, { useGraphQL }),
+			// mongodb Types support -- composite types are embedded values, not entities with
+			// their own create/update endpoints, so they get no DTOs.
 			...this.dmmf.datamodel.types.map((model) =>
 				this.getClass({ model, useGraphQL }),
 			),
 		]
+	}
+
+	private getModelClassesWithDtos = (
+		models: readonly DMMF.Model[],
+		input: Omit<ConvertModelInput, 'model'>,
+	): ClassComponent[] => {
+		return models.flatMap((model) => {
+			const baseClass = this.getClass({ model, ...input })
+			if (!this.config.makeDtoFiles) {
+				return [baseClass]
+			}
+			return [baseClass, ...this.getDtoClasses(model, baseClass)]
+		})
 	}
 
 	convertField = (dmmfField: DMMF.Field): FieldComponent => {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -66,6 +66,10 @@ export const PrismaClassGeneratorOptions = {
 		desc: 'separate relation fields',
 		defaultValue: false,
 	},
+	makeDtoFiles: {
+		desc: 'generate Create<Model>/Update<Model> DTO classes composed from the model class with NestJS mapped types -- fields the schema says the database produces (function @default(...), @updatedAt) and relation fields are omitted from Create; Update is PartialType of Create',
+		defaultValue: false,
+	},
 	useSwagger: {
 		desc: 'use swagger decorstor',
 		defaultValue: true,
@@ -119,6 +123,7 @@ export interface PrismaClassGeneratorConfig {
 	makeIndexFile?: boolean
 	dryRun?: boolean
 	separateRelationFields?: boolean
+	makeDtoFiles?: boolean
 	useSwagger?: boolean
 	useGraphQL?: boolean
 	useValidation?: boolean

--- a/src/templates/dto.template.ts
+++ b/src/templates/dto.template.ts
@@ -1,0 +1,9 @@
+// A DTO class has no body of its own -- it's a composition of a generated model class with
+// NestJS's mapped-type helpers, which carry both the Swagger metadata and the class-validator
+// rules across (verified: OmitType keeps @IsString(), PartialType keeps it but makes it
+// optional). Generating the composition rather than a fully expanded copy of every field means
+// there is exactly one place a field's type/validators are declared.
+export const DTO_CLASS_TEMPLATE = `#!{IMPORTS}
+
+export class #!{NAME} extends #!{EXTENDS} {}
+`


### PR DESCRIPTION
Closes the last real item on the README's "Future Plan".

## Why now — the stated philosophy had already been overtaken

Per-model Create/Update DTOs were deferred on the grounds that deciding what a create payload looks like belongs to the developer. That reasoning no longer matches what this generator does:

- `useValidation` decides which validators are right for a field
- `useSerialization` + `/// @exclude` decide what leaves a response
- `validateNestedRelations` assumes a nested payload shape
- a literal `@default(...)` already becomes a Swagger `example`

DTOs were the one place the old statement was still being applied. **Applying the repo's actual rule produces this feature rather than blocking it.**

That rule is *"reflect what the schema states, never guess from a field's name"* — the #34/#56/#76 Date misdetection being the cautionary tale. Which fields a client can't supply on create is stated outright in the schema, so nothing here is inferred:

| field | schema fact | in `Create`? |
|---|---|---|
| `id Int @id @default(autoincrement())` | function default | omitted |
| `createdAt DateTime @default(now())` | function default | omitted |
| `computed String @default(dbgenerated(...))` | function default | omitted |
| `updatedAt DateTime @updatedAt` | `isUpdatedAt` | omitted |
| `author Author @relation(...)` | relation | omitted |
| **`authorId String`** | FK scalar | **kept** — what a REST client actually posts |
| **`views Int @default(0)`** | *literal* default | **kept** — "there's a fallback" ≠ "you may not set it" |
| **`id String @id`** (no default) | no default | **kept** — the caller has to provide it |

DMMF represents function defaults as an `{ name, args }` object, which is exactly what distinguishes them from literal ones — verified against real DMMF, not assumed.

## What it generates

Compositions, not copies:

```ts
// create_post.ts
import { Post } from './post'
import { OmitType } from '@nestjs/swagger'
export class CreatePost extends OmitType(Post, ['id', 'createdAt', 'updatedAt', 'author'] as const) {}

// update_post.ts
import { CreatePost } from './create_post'
import { PartialType } from '@nestjs/swagger'
export class UpdatePost extends PartialType(CreatePost) {}
```

A field's type, Swagger metadata and validators stay declared in **exactly one place**. This is deliberately a different shape from `prisma-generator-nestjs-dto`'s fully expanded per-DTO classes — and it's the same composition the README FAQ has always told people to write by hand. Mapped types come from `@nestjs/swagger` when `useSwagger` is on, `@nestjs/mapped-types` otherwise.

## Verified end to end, not just as strings

Generated output (models + DTOs + enums + nullable fields + `useNonNullableAssertions`) compiled against a **real `@nestjs/swagger` install**:

```
$ tsc --noEmit --strict
(no output — 0 errors)
```

And at runtime, the mapped types really do carry the decorators through:

```
1) Create에 id/createdAt/updatedAt/author 키 없음 : OK
2) Create 잘못된 값 → title(isString) views(isInt) authorId(isString) status(isEnum)
3) Create 올바른 값 → 에러 없음
4) Update {} → 에러 없음 (partial)
5) Update {title:123} → title(isString)
```

That exercise is also what turned up the TS1263 bug fixed separately in #106.

## Implementation notes

- `ClassComponent` gains `extendsExpression`/`generatedClassImports`/`externalImports`; with `extendsExpression` set it renders from a new `DTO_CLASS_TEMPLATE` with no body of its own.
- The base-class import goes through `FileComponent.TEMP_PREFIX` like relation imports, so it resolves to the real snake_case path once every file's location is known. Unlike a relation field it must be a **value** import — the name appears in an `extends` clause, which a type-only import can't serve.
- Omitted keys are read off the generated **base class's fields**, not off the model, so `separateRelationFields` (whose base has already dropped relations) and `/// @skip` can't produce an `OmitType` key that isn't `keyof` the class. There's a test for exactly that.
- GraphQL helper imports are skipped for DTO files — with no fields they'd be guaranteed-unused.
- Composite types (MongoDB `type` blocks) get no DTOs: embedded values, not entities with endpoints.

## Compatibility

**Off by default.** Fixture snapshots are unchanged, so existing output is byte-identical. 228 tests pass (13 new). README options/FAQ/comparison table and the "Future Plan" list are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)